### PR TITLE
Add new variables for including and excluding service check tags

### DIFF
--- a/dd-agent-data-variables.tf
+++ b/dd-agent-data-variables.tf
@@ -3,11 +3,6 @@ variable "dd_agent_data_enabled" {
   default = true
 }
 
-variable "dd_agent_data_freshness_minutes" {
-  type    = number
-  default = 15
-}
-
 variable "dd_agent_data_severity" {
   type    = string
   default = "major"
@@ -26,6 +21,16 @@ variable "dd_agent_data_docs" {
 variable "dd_agent_data_filter_override" {
   type    = string
   default = ""
+}
+
+variable "dd_agent_data_include_tags_override" {
+  type    = list(string)
+  default = null
+}
+
+variable "dd_agent_data_exclude_tags_override" {
+  type    = list(string)
+  default = null
 }
 
 variable "dd_agent_alerting_enabled" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  service_check_include_tags = coalesce(
+    var.service_check_include_tags,
+    ["service:${var.service}"]
+  )
+
+  service_check_exclude_tags = coalesce(
+    var.service_check_exclude_tags,
+    []
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,16 @@ variable "locked" {
   type    = bool
   default = true
 }
+
+# The default values for the following two variables can be found in the
+# locals.tf file. As a local, the fallback contain references to other
+# variables.
+variable "service_check_include_tags" {
+  type    = list(string)
+  default = null
+}
+
+variable "service_check_exclude_tags" {
+  type    = list(string)
+  default = null
+}


### PR DESCRIPTION
Service checks do not use the filter string and do not support the same features as the filter string does. Now we require the user to specify the tags separate from the filter string.

This uses the terraform-datadog-service-check-monitor under the hood that builds the query for us.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
