### PR TITLE
Update generic monitor to 0.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,5 @@
 # Local .terraform directories
 **/.terraform/*
 
-# .tfstate files
-*.tfstate
-*.tfstate.*
-
-# Crash log files
-crash.log
-
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
-#
-# example.tfvars
-
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# Include override files you do wish to add to version control using negated pattern
-#
-# !example_override.tf
-
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# Lock should be present in top level module
+.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.12
+    hooks:
+      - id: terraform-fmt
+      - id: terraform-validate
+      - id: tflint
+      - id: shellcheck

--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
-# system
 
-Example usage:
-```terraform
-module "system" {
-  source = "git@github.com:kabisa/terraform-datadog-system.git?ref=0.1"
-  env                             = "prd"
-  filter_str                      = "app:myapp"
-  required_services_config        = {
-    sshd : {}
-  }
-  notification_channel            = "@kabisa"
-  service                         = "myapp"
-}
-```
+# Getting started
+[pre-commit](http://pre-commit.com/) was used to do Terraform linting and validating.
 
+Steps:
+   - Install [pre-commit](http://pre-commit.com/). E.g. `brew install pre-commit`.
+   - Run `pre-commit install` in the repo.
+   - That’s it! Now every time you commit a code change (`.tf` file), the hooks in the `hooks:` config `.pre-commit-config.yaml` will execute.
+
+
+[//]: # (This file is generated. Do not edit)
+
+# Terraform module for Datadog System
 
 TOC:
 <!--ts-->
-   * [system](#system)
+   * [Getting started](#getting-started)
+   * [Terraform module for Datadog System](#terraform-module-for-datadog-system)
       * [Datadog Agent](#datadog-agent)
       * [Required Services](#required-services)
       * [Bytes Sent](#bytes-sent)
-      * [Uptime](#uptime)
       * [Packets Out Errors](#packets-out-errors)
       * [Memory Free Percent](#memory-free-percent)
       * [Datadog Agent Data](#datadog-agent-data)
@@ -31,152 +28,142 @@ TOC:
       * [Memory Free Bytes](#memory-free-bytes)
       * [Bytes Received](#bytes-received)
       * [Disk Iowait](#disk-iowait)
+      * [Reboot](#reboot)
       * [CPU](#cpu)
       * [Module Variables](#module-variables)
 
-<!-- Added by: sjuuljanssen, at: za 13 mrt 2021 15:51:20 CET -->
+<!-- Added by: sjuuljanssen, at: vr 25 jun 2021 16:56:33 CEST -->
 
 <!--te-->
 
 ## Datadog Agent
 
-| variable                       | default                                  | required | description  |
-|--------------------------------|------------------------------------------|----------|--------------|
-| dd_agent_enabled               | True                                     | No       |              |
-| dd_agent_evaluation_period     | last_15m                                 | No       |              |
-| dd_agent_severity              | major                                    | No       |              |
-| dd_agent_note                  | ""                                       | No       |              |
-| dd_agent_docs                  | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |              |
-| dd_agent_filter_override       | ""                                       | No       |              |
-| dd_agent_data_alerting_enabled | True                                     | No       |              |
+| variable                       | default                                  | required | description                      |
+|--------------------------------|------------------------------------------|----------|----------------------------------|
+| dd_agent_enabled               | True                                     | No       |                                  |
+| dd_agent_evaluation_period     | last_15m                                 | No       |                                  |
+| dd_agent_note                  | ""                                       | No       |                                  |
+| dd_agent_docs                  | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
+| dd_agent_filter_override       | ""                                       | No       |                                  |
+| dd_agent_data_alerting_enabled | True                                     | No       |                                  |
+| dd_agent_data_priority         | 2                                        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Required Services
 
-| variable                                     | default  | required | description  |
-|----------------------------------------------|----------|----------|--------------|
-| required_services_config                     | {}       | No       |              |
-| required_services_default_freshness_duration | 5m       | No       |              |
-| required_services_default_severity           | major    | No       |              |
-| required_services_default_note               | ""       | No       |              |
-| required_services_default_docs               | ""       | No       |              |
-| required_services_filter_override            | ""       | No       |              |
-| required_services_alerting_enabled           | True     | No       |              |
+| variable                                     | default  | required | description                      |
+|----------------------------------------------|----------|----------|----------------------------------|
+| required_services_enabled                    | True     | No       |                                  |
+| required_services_config                     | {}       | No       |                                  |
+| required_services_default_freshness_duration | 5m       | No       |                                  |
+| required_services_default_note               | ""       | No       |                                  |
+| required_services_default_docs               | ""       | No       |                                  |
+| required_services_filter_override            | ""       | No       |                                  |
+| required_services_alerting_enabled           | True     | No       |                                  |
+| required_services_default_priority           | 2        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Bytes Sent
 
-| variable                     | default  | required | description  |
-|------------------------------|----------|----------|--------------|
-| bytes_sent_enabled           | True     | No       |              |
-| bytes_sent_warning           | 4000000  | No       |              |
-| bytes_sent_critical          | 5000000  | No       |              |
-| bytes_sent_evaluation_period | last_30m | No       |              |
-| bytes_sent_severity          | minor    | No       |              |
-| bytes_sent_note              | ""       | No       |              |
-| bytes_sent_docs              | ""       | No       |              |
-| bytes_sent_filter_override   | ""       | No       |              |
-| bytes_sent_alerting_enabled  | True     | No       |              |
-
-
-## Uptime
-
-| variable                | default  | required | description  |
-|-------------------------|----------|----------|--------------|
-| reboot_enabled          | True     | No       |              |
-| reboot_severity         | critical | No       |              |
-| reboot_note             | ""       | No       |              |
-| reboot_docs             | ""       | No       |              |
-| reboot_filter_override  | ""       | No       |              |
-| reboot_alerting_enabled | True     | No       |              |
+| variable                     | default  | required | description                      |
+|------------------------------|----------|----------|----------------------------------|
+| bytes_sent_enabled           | True     | No       |                                  |
+| bytes_sent_warning           | 4000000  | No       |                                  |
+| bytes_sent_critical          | 5000000  | No       |                                  |
+| bytes_sent_evaluation_period | last_30m | No       |                                  |
+| bytes_sent_note              | ""       | No       |                                  |
+| bytes_sent_docs              | ""       | No       |                                  |
+| bytes_sent_filter_override   | ""       | No       |                                  |
+| bytes_sent_alerting_enabled  | True     | No       |                                  |
+| bytes_sent_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Packets Out Errors
 
-| variable                             | default                                  | required | description  |
-|--------------------------------------|------------------------------------------|----------|--------------|
-| packets_out_errors_enabled           | True                                     | No       |              |
-| packets_out_errors_warning           | 0.5                                      | No       |              |
-| packets_out_errors_critical          | 1                                        | No       |              |
-| packets_out_errors_evaluation_period | last_15m                                 | No       |              |
-| packets_out_errors_severity          | minor                                    | No       |              |
-| packets_out_errors_note              | ""                                       | No       |              |
-| packets_out_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |              |
-| packets_out_errors_filter_override   | ""                                       | No       |              |
-| packets_out_errors_alerting_enabled  | True                                     | No       |              |
+| variable                             | default                                  | required | description                      |
+|--------------------------------------|------------------------------------------|----------|----------------------------------|
+| packets_out_errors_enabled           | True                                     | No       |                                  |
+| packets_out_errors_warning           | 0.5                                      | No       |                                  |
+| packets_out_errors_critical          | 1                                        | No       |                                  |
+| packets_out_errors_evaluation_period | last_15m                                 | No       |                                  |
+| packets_out_errors_note              | ""                                       | No       |                                  |
+| packets_out_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
+| packets_out_errors_filter_override   | ""                                       | No       |                                  |
+| packets_out_errors_alerting_enabled  | True                                     | No       |                                  |
+| packets_out_errors_priority          | 3                                        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Memory Free Percent
 
-| variable                              | default  | required | description  |
-|---------------------------------------|----------|----------|--------------|
-| memory_free_percent_enabled           | True     | No       |              |
-| memory_free_percent_warning           | 20       | No       |              |
-| memory_free_percent_critical          | 10       | No       |              |
-| memory_free_percent_evaluation_period | last_5m  | No       |              |
-| memory_free_percent_severity          | critical | No       |              |
-| memory_free_percent_note              | ""       | No       |              |
-| memory_free_percent_docs              | ""       | No       |              |
-| memory_free_percent_filter_override   | ""       | No       |              |
-| memory_free_percent_alerting_enabled  | True     | No       |              |
+| variable                              | default  | required | description                      |
+|---------------------------------------|----------|----------|----------------------------------|
+| memory_free_percent_enabled           | True     | No       |                                  |
+| memory_free_percent_warning           | 20       | No       |                                  |
+| memory_free_percent_critical          | 10       | No       |                                  |
+| memory_free_percent_evaluation_period | last_5m  | No       |                                  |
+| memory_free_percent_note              | ""       | No       |                                  |
+| memory_free_percent_docs              | ""       | No       |                                  |
+| memory_free_percent_filter_override   | ""       | No       |                                  |
+| memory_free_percent_alerting_enabled  | True     | No       |                                  |
+| memory_free_percent_priority          | 2        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Datadog Agent Data
 
-| variable                        | default                                  | required | description  |
-|---------------------------------|------------------------------------------|----------|--------------|
-| dd_agent_data_enabled           | True                                     | No       |              |
-| dd_agent_data_freshness_minutes | 15                                       | No       |              |
-| dd_agent_data_severity          | major                                    | No       |              |
-| dd_agent_data_note              | ""                                       | No       |              |
-| dd_agent_data_docs              | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |              |
-| dd_agent_data_filter_override   | ""                                       | No       |              |
-| dd_agent_alerting_enabled       | True                                     | No       |              |
+| variable                        | default                                  | required | description                      |
+|---------------------------------|------------------------------------------|----------|----------------------------------|
+| dd_agent_data_enabled           | True                                     | No       |                                  |
+| dd_agent_data_freshness_minutes | 15                                       | No       |                                  |
+| dd_agent_data_note              | ""                                       | No       |                                  |
+| dd_agent_data_docs              | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
+| dd_agent_data_filter_override   | ""                                       | No       |                                  |
+| dd_agent_alerting_enabled       | True                                     | No       |                                  |
+| dd_agent_priority               | 2                                        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Packets In Errors
 
-| variable                            | default                                  | required | description  |
-|-------------------------------------|------------------------------------------|----------|--------------|
-| packets_in_errors_enabled           | True                                     | No       |              |
-| packets_in_errors_warning           | 0.5                                      | No       |              |
-| packets_in_errors_critical          | 1                                        | No       |              |
-| packets_in_errors_evaluation_period | last_15m                                 | No       |              |
-| packets_in_errors_severity          | minor                                    | No       |              |
-| packets_in_errors_note              | ""                                       | No       |              |
-| packets_in_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |              |
-| packets_in_errors_filter_override   | ""                                       | No       |              |
-| packets_in_errors_alerting_enabled  | True                                     | No       |              |
+| variable                            | default                                  | required | description                      |
+|-------------------------------------|------------------------------------------|----------|----------------------------------|
+| packets_in_errors_enabled           | True                                     | No       |                                  |
+| packets_in_errors_warning           | 0.5                                      | No       |                                  |
+| packets_in_errors_critical          | 1                                        | No       |                                  |
+| packets_in_errors_evaluation_period | last_15m                                 | No       |                                  |
+| packets_in_errors_note              | ""                                       | No       |                                  |
+| packets_in_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
+| packets_in_errors_filter_override   | ""                                       | No       |                                  |
+| packets_in_errors_alerting_enabled  | True                                     | No       |                                  |
+| packets_in_errors_priority          | 3                                        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Swap
 
-| variable                            | default  | required | description  |
-|-------------------------------------|----------|----------|--------------|
-| swap_percent_free_enabled           | True     | No       |              |
-| swap_percent_free_warning           | 20       | No       |              |
-| swap_percent_free_critical          | 10       | No       |              |
-| swap_percent_free_evaluation_period | last_5m  | No       |              |
-| swap_percent_free_severity          | minor    | No       |              |
-| swap_percent_free_note              | ""       | No       |              |
-| swap_percent_free_docs              | ""       | No       |              |
-| swap_percent_free_filter_override   | ""       | No       |              |
-| swap_percent_free_alerting_enabled  | True     | No       |              |
+| variable                            | default  | required | description                      |
+|-------------------------------------|----------|----------|----------------------------------|
+| swap_percent_free_enabled           | True     | No       |                                  |
+| swap_percent_free_warning           | 15       | No       |                                  |
+| swap_percent_free_critical          | 10       | No       |                                  |
+| swap_percent_free_evaluation_period | last_5m  | No       |                                  |
+| swap_percent_free_note              | ""       | No       |                                  |
+| swap_percent_free_docs              | ""       | No       |                                  |
+| swap_percent_free_filter_override   | ""       | No       |                                  |
+| swap_percent_free_alerting_enabled  | True     | No       |                                  |
+| swap_percent_free_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Disk Free
 
-| variable                    | default  | required | description  |
-|-----------------------------|----------|----------|--------------|
-| disk_free_enabled           | True     | No       |              |
-| disk_free_warning           | 25       | No       |              |
-| disk_free_critical          | 10       | No       |              |
-| disk_free_evaluation_period | last_5m  | No       |              |
-| disk_free_severity          | critical | No       |              |
-| disk_free_note              | ""       | No       |              |
-| disk_free_docs              | ""       | No       |              |
-| disk_free_filter_override   | ""       | No       |              |
-| disk_free_alerting_enabled  | True     | No       |              |
+| variable                    | default  | required | description                      |
+|-----------------------------|----------|----------|----------------------------------|
+| disk_free_enabled           | True     | No       |                                  |
+| disk_free_warning           | 20       | No       |                                  |
+| disk_free_critical          | 10       | No       |                                  |
+| disk_free_evaluation_period | last_5m  | No       |                                  |
+| disk_free_note              | ""       | No       |                                  |
+| disk_free_docs              | ""       | No       |                                  |
+| disk_free_filter_override   | ""       | No       |                                  |
+| disk_free_alerting_enabled  | True     | No       |                                  |
+| disk_free_priority          | 1        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Memory Free Bytes
@@ -187,56 +174,68 @@ TOC:
 | memory_free_bytes_warning           | 2000000000 | No       |                                                                                      |
 | memory_free_bytes_critical          | 1000000000 | No       |                                                                                      |
 | memory_free_bytes_evaluation_period | last_5m    | No       |                                                                                      |
-| memory_free_bytes_severity          | critical   | No       |                                                                                      |
 | memory_free_bytes_note              | ""         | No       |                                                                                      |
 | memory_free_bytes_docs              | ""         | No       |                                                                                      |
 | memory_free_bytes_filter_override   | ""         | No       |                                                                                      |
-| memory_free_alerting_enabled        | True       | No       |                                                                                      |
+| memory_free_bytes_alerting_enabled  | True       | No       |                                                                                      |
+| memory_free_bytes_priority          | 2          | No       | Number from 1 (high) to 5 (low).                                                     |
 
 
 ## Bytes Received
 
-| variable                         | default  | required | description  |
-|----------------------------------|----------|----------|--------------|
-| bytes_received_enabled           | True     | No       |              |
-| bytes_received_warning           | 4000000  | No       |              |
-| bytes_received_critical          | 5000000  | No       |              |
-| bytes_received_evaluation_period | last_30m | No       |              |
-| bytes_received_severity          | minor    | No       |              |
-| bytes_received_note              | ""       | No       |              |
-| bytes_received_docs              | ""       | No       |              |
-| bytes_received_filter_override   | ""       | No       |              |
-| bytes_received_alerting_enabled  | True     | No       |              |
+| variable                         | default  | required | description                      |
+|----------------------------------|----------|----------|----------------------------------|
+| bytes_received_enabled           | True     | No       |                                  |
+| bytes_received_warning           | 4000000  | No       |                                  |
+| bytes_received_critical          | 5000000  | No       |                                  |
+| bytes_received_evaluation_period | last_30m | No       |                                  |
+| bytes_received_note              | ""       | No       |                                  |
+| bytes_received_docs              | ""       | No       |                                  |
+| bytes_received_filter_override   | ""       | No       |                                  |
+| bytes_received_alerting_enabled  | True     | No       |                                  |
+| bytes_received_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Disk Iowait
 
-| variable                       | default                                  | required | description  |
-|--------------------------------|------------------------------------------|----------|--------------|
-| disk_io_wait_enabled           | True                                     | No       |              |
-| disk_io_wait_warning           | 80                                       | No       |              |
-| disk_io_wait_critical          | 95                                       | No       |              |
-| disk_io_wait_evaluation_period | last_30m                                 | No       |              |
-| disk_io_wait_severity          | critical                                 | No       |              |
-| disk_io_wait_note              | ""                                       | No       |              |
-| disk_io_wait_docs              | The CPU is mainly waiting for data to be written on disk. This means in general that application running on this machine is stalled | No       |              |
-| disk_io_wait_filter_override   | ""                                       | No       |              |
-| disk_io_wait_alerting_enabled  | True                                     | No       |              |
+| variable                       | default                                  | required | description                      |
+|--------------------------------|------------------------------------------|----------|----------------------------------|
+| disk_io_wait_enabled           | True                                     | No       |                                  |
+| disk_io_wait_warning           | 80                                       | No       |                                  |
+| disk_io_wait_critical          | 95                                       | No       |                                  |
+| disk_io_wait_evaluation_period | last_30m                                 | No       |                                  |
+| disk_io_wait_note              | ""                                       | No       |                                  |
+| disk_io_wait_docs              | The CPU is mainly waiting for data to be written on disk. This means in general that application running on this machine is stalled | No       |                                  |
+| disk_io_wait_filter_override   | ""                                       | No       |                                  |
+| disk_io_wait_alerting_enabled  | True                                     | No       |                                  |
+| disk_io_wait_priority          | 2                                        | No       | Number from 1 (high) to 5 (low). |
+
+
+## Reboot
+
+| variable                | default  | required | description                      |
+|-------------------------|----------|----------|----------------------------------|
+| reboot_enabled          | True     | No       |                                  |
+| reboot_note             | ""       | No       |                                  |
+| reboot_docs             | ""       | No       |                                  |
+| reboot_filter_override  | ""       | No       |                                  |
+| reboot_alerting_enabled | True     | No       |                                  |
+| reboot_priority         | 3        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## CPU
 
-| variable              | default  | required | description  |
-|-----------------------|----------|----------|--------------|
-| cpu_enabled           | True     | No       |              |
-| cpu_warning           | 80       | No       |              |
-| cpu_critical          | 95       | No       |              |
-| cpu_evaluation_period | last_30m | No       |              |
-| cpu_severity          | major    | No       |              |
-| cpu_note              | ""       | No       |              |
-| cpu_docs              | ""       | No       |              |
-| cpu_filter_override   | ""       | No       |              |
-| cpu_alerting_enabled  | True     | No       |              |
+| variable              | default  | required | description                      |
+|-----------------------|----------|----------|----------------------------------|
+| cpu_enabled           | True     | No       |                                  |
+| cpu_warning           | 80       | No       |                                  |
+| cpu_critical          | 95       | No       |                                  |
+| cpu_evaluation_period | last_30m | No       |                                  |
+| cpu_note              | ""       | No       |                                  |
+| cpu_docs              | ""       | No       |                                  |
+| cpu_filter_override   | ""       | No       |                                  |
+| cpu_alerting_enabled  | True     | No       |                                  |
+| cpu_priority          | 2        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Module Variables
@@ -249,5 +248,8 @@ TOC:
 | service              |          | Yes      |              |
 | notification_channel |          | Yes      |              |
 | additional_tags      | []       | No       |              |
+| name_prefix          | ""       | No       |              |
+| name_suffix          | ""       | No       |              |
+| locked               | True     | No       |              |
 
 

--- a/bytes-received-variables.tf
+++ b/bytes-received-variables.tf
@@ -20,11 +20,6 @@ variable "bytes_received_evaluation_period" {
   default = "last_30m"
 }
 
-variable "bytes_received_severity" {
-  type    = string
-  default = "minor"
-}
-
 variable "bytes_received_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "bytes_received_alerting_enabled" {
   default = true
 }
 
-variable "bytes_received_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "bytes_received_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "bytes_received_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/bytes-received.tf
+++ b/bytes-received.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "bytes_received" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Bytes received"
   query            = "avg(${var.bytes_received_evaluation_period}):avg:system.net.bytes_rcvd{${local.bytes_received_filter}} by {host} > ${var.bytes_received_critical}"
   alert_message    = "High ingress traffic on ${var.service} Node {{host.name}} ({{value}})"
   recovery_message = "Ingress traffic on ${var.service} Node {{host.name}} Recovered ({{value}})"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.bytes_received_enabled
@@ -26,9 +19,15 @@ module "bytes_received" {
   warning_threshold  = var.bytes_received_warning
   critical_threshold = var.bytes_received_critical
   priority           = var.bytes_received_priority
-  severity           = var.bytes_received_severity
   docs               = var.bytes_received_docs
   note               = var.bytes_received_note
-  name_prefix        = var.bytes_received_name_prefix
-  name_suffix        = var.bytes_received_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/bytes-sent-variables.tf
+++ b/bytes-sent-variables.tf
@@ -20,11 +20,6 @@ variable "bytes_sent_evaluation_period" {
   default = "last_30m"
 }
 
-variable "bytes_sent_severity" {
-  type    = string
-  default = "minor"
-}
-
 variable "bytes_sent_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "bytes_sent_alerting_enabled" {
   default = true
 }
 
-variable "bytes_sent_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "bytes_sent_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "bytes_sent_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/bytes-sent.tf
+++ b/bytes-sent.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "bytes_sent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Bytes sent"
   query            = "avg(${var.bytes_sent_evaluation_period}):avg:system.net.bytes_sent{${local.bytes_sent_filter}} by {host} > ${var.bytes_sent_critical}"
   alert_message    = "High egress traffic on ${var.service} Node {{host.name}} ({{value}})"
   recovery_message = "High egress traffic on ${var.service} Node {{host.name}} Recovered ({{value}})"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.bytes_sent_enabled
@@ -26,9 +19,15 @@ module "bytes_sent" {
   warning_threshold  = var.bytes_sent_warning
   critical_threshold = var.bytes_sent_critical
   priority           = var.bytes_sent_priority
-  severity           = var.bytes_sent_severity
   docs               = var.bytes_sent_docs
   note               = var.bytes_sent_note
-  name_prefix        = var.bytes_sent_name_prefix
-  name_suffix        = var.bytes_sent_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/cpu-variables.tf
+++ b/cpu-variables.tf
@@ -18,11 +18,6 @@ variable "cpu_evaluation_period" {
   default = "last_30m"
 }
 
-variable "cpu_severity" {
-  type    = string
-  default = "major"
-}
-
 variable "cpu_note" {
   type    = string
   default = ""
@@ -43,19 +38,9 @@ variable "cpu_alerting_enabled" {
   default = true
 }
 
-variable "cpu_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "cpu_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "cpu_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/cpu.tf
+++ b/cpu.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "cpu" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - High CPU"
   query            = "avg(${var.cpu_evaluation_period}):avg:system.cpu.user{${local.cpu_filter}} by {host} + avg:system.cpu.system{${local.cpu_filter}} by {host} > ${var.cpu_critical}"
   alert_message    = "High CPU usage on ${var.service} Node {{host.name}} ({{value}} %)"
   recovery_message = "CPU usage on Vault ${var.service} {{host.name}} Recovered ({{value}} %)"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.cpu_enabled
@@ -26,9 +19,15 @@ module "cpu" {
   warning_threshold  = var.cpu_warning
   critical_threshold = var.cpu_critical
   priority           = var.cpu_priority
-  severity           = var.cpu_severity
   docs               = var.cpu_docs
   note               = var.cpu_note
-  name_prefix        = var.cpu_name_prefix
-  name_suffix        = var.cpu_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/dd-agent-data-variables.tf
+++ b/dd-agent-data-variables.tf
@@ -8,11 +8,6 @@ variable "dd_agent_data_freshness_minutes" {
   default = 15
 }
 
-variable "dd_agent_data_severity" {
-  type    = string
-  default = "major"
-}
-
 variable "dd_agent_data_note" {
   type    = string
   default = ""
@@ -33,19 +28,9 @@ variable "dd_agent_alerting_enabled" {
   default = true
 }
 
-variable "dd_agent_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "dd_agent_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "dd_agent_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/dd-agent-data.tf
+++ b/dd-agent-data.tf
@@ -31,7 +31,6 @@ module "dd_agent_data" {
   warning_threshold  = 1
   ok_threshold       = 1
   priority           = var.dd_agent_data_priority
-  severity           = var.dd_agent_data_severity
   docs               = var.dd_agent_data_docs
   note               = var.dd_agent_data_note
 

--- a/dd-agent-data.tf
+++ b/dd-agent-data.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 module "dd_agent_data" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   type                = "service check"
   name                = "System - Datadog data missing"
@@ -20,13 +20,6 @@ module "dd_agent_data" {
   no_data_timeframe   = 2
   notify_no_data      = true
 
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-
   # monitor level vars
   enabled            = var.dd_agent_data_enabled
   alerting_enabled   = var.dd_agent_data_alerting_enabled
@@ -34,9 +27,15 @@ module "dd_agent_data" {
   warning_threshold  = 1
   ok_threshold       = 1
   priority           = var.dd_agent_data_priority
-  severity           = var.dd_agent_data_severity
   docs               = var.dd_agent_data_docs
   note               = var.dd_agent_data_note
-  name_prefix        = var.dd_agent_data_name_prefix
-  name_suffix        = var.dd_agent_data_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/dd-agent-variables.tf
+++ b/dd-agent-variables.tf
@@ -8,11 +8,6 @@ variable "dd_agent_evaluation_period" {
   default = "last_15m"
 }
 
-variable "dd_agent_severity" {
-  type    = string
-  default = "major"
-}
-
 variable "dd_agent_note" {
   type    = string
   default = ""
@@ -33,19 +28,9 @@ variable "dd_agent_data_alerting_enabled" {
   default = true
 }
 
-variable "dd_agent_data_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "dd_agent_data_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "dd_agent_data_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/dd-agent.tf
+++ b/dd-agent.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "dd_agent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Datadog agent not running"
   query            = "avg(${var.dd_agent_evaluation_period}):avg:datadog.agent.running{${local.dd_agent_filter}} by {host} < 1"
   alert_message    = "Datadog Agent not running is not running on ${var.service} Node {{host.name}} please check."
   recovery_message = "Datadog Agent is back on ${var.service} Node {{host.name}}"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled          = var.dd_agent_enabled
@@ -26,9 +19,15 @@ module "dd_agent" {
   # no warning possible
   critical_threshold = 1
   priority           = var.dd_agent_priority
-  severity           = var.dd_agent_severity
   docs               = var.dd_agent_docs
   note               = var.dd_agent_note
-  name_prefix        = var.dd_agent_name_prefix
-  name_suffix        = var.dd_agent_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-free-variables.tf
+++ b/disk-free-variables.tf
@@ -20,11 +20,6 @@ variable "disk_free_evaluation_period" {
   default = "last_5m"
 }
 
-variable "disk_free_severity" {
-  type    = string
-  default = "critical"
-}
-
 variable "disk_free_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "disk_free_alerting_enabled" {
   default = true
 }
 
-variable "disk_free_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "disk_free_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "disk_free_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 1
 }

--- a/disk-free.tf
+++ b/disk-free.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "disk_free" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Disk Free"
   query            = "avg(${var.disk_free_evaluation_period}):( min:system.disk.free{${local.disk_free_filter}} by {host,device} / min:system.disk.total{${local.disk_free_filter}} by {host,device} ) * 100 < ${var.disk_free_critical}"
   alert_message    = "Available disk volume {{device.name}} on ${var.service} Node {{host.name}} has dropped below {{threshold}} ( {{device.name}}  has {{value}}% available on {{host.name}} )"
   recovery_message = "Available disk volume {{device.name}} on ${var.service} Node {{host.name}} has recovered ( {{device.name}}  has {{value}}% available on {{host.name}} )"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.disk_free_enabled
@@ -26,9 +19,15 @@ module "disk_free" {
   warning_threshold  = var.disk_free_warning
   critical_threshold = var.disk_free_critical
   priority           = var.disk_free_priority
-  severity           = var.disk_free_severity
   docs               = var.disk_free_docs
   note               = var.disk_free_note
-  name_prefix        = var.disk_free_name_prefix
-  name_suffix        = var.disk_free_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-iowait-variables.tf
+++ b/disk-iowait-variables.tf
@@ -20,11 +20,6 @@ variable "disk_io_wait_evaluation_period" {
   default = "last_30m"
 }
 
-variable "disk_io_wait_severity" {
-  type    = string
-  default = "critical"
-}
-
 variable "disk_io_wait_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "disk_io_wait_alerting_enabled" {
   default = true
 }
 
-variable "disk_io_wait_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "disk_io_wait_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "disk_io_wait_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/disk-iowait.tf
+++ b/disk-iowait.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "disk_io_wait" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Disk IO Wait"
   query            = "avg(${var.disk_io_wait_evaluation_period}):avg:system.cpu.iowait{${local.disk_io_wait_filter}} by {host} > ${var.disk_io_wait_critical}"
   alert_message    = "High IO waits for CPU on ${var.service} Node {{host.name}} ({{value}} %)"
   recovery_message = "IO waits for CPU on ${var.service} Node {{host.name}} Recovered ({{value}} %) "
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.disk_io_wait_enabled
@@ -26,9 +19,15 @@ module "disk_io_wait" {
   warning_threshold  = var.disk_io_wait_warning
   critical_threshold = var.disk_io_wait_critical
   priority           = var.disk_io_wait_priority
-  severity           = var.disk_io_wait_severity
   docs               = var.disk_io_wait_docs
   note               = var.disk_io_wait_note
-  name_prefix        = var.disk_io_wait_name_prefix
-  name_suffix        = var.disk_io_wait_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/memory-free-bytes-variables.tf
+++ b/memory-free-bytes-variables.tf
@@ -21,11 +21,6 @@ variable "memory_free_bytes_evaluation_period" {
   default = "last_5m"
 }
 
-variable "memory_free_bytes_severity" {
-  type    = string
-  default = "critical"
-}
-
 variable "memory_free_bytes_note" {
   type    = string
   default = ""
@@ -46,19 +41,9 @@ variable "memory_free_bytes_alerting_enabled" {
   default = true
 }
 
-variable "memory_free_bytes_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "memory_free_bytes_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "memory_free_bytes_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/memory-free-bytes.tf
+++ b/memory-free-bytes.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "memory_free_bytes" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Memory Free Bytes"
   query            = "avg(${var.memory_free_bytes_evaluation_period}):min:system.mem.free{${local.memory_free_bytes_filter}} by {host} < ${var.memory_free_bytes_critical}"
   alert_message    = "Available memory on ${var.service} Node {{host.name}} has dropped below {{threshold}} and has {{value}} available"
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.memory_free_bytes_enabled
@@ -26,9 +19,15 @@ module "memory_free_bytes" {
   warning_threshold  = var.memory_free_bytes_warning
   critical_threshold = var.memory_free_bytes_critical
   priority           = var.memory_free_bytes_priority
-  severity           = var.memory_free_bytes_severity
   docs               = var.memory_free_bytes_docs
   note               = var.memory_free_bytes_note
-  name_prefix        = var.memory_free_bytes_name_prefix
-  name_suffix        = var.memory_free_bytes_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/memory-free-percent-variables.tf
+++ b/memory-free-percent-variables.tf
@@ -20,11 +20,6 @@ variable "memory_free_percent_evaluation_period" {
   default = "last_5m"
 }
 
-variable "memory_free_percent_severity" {
-  type    = string
-  default = "critical"
-}
-
 variable "memory_free_percent_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "memory_free_percent_alerting_enabled" {
   default = true
 }
 
-variable "memory_free_percent_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "memory_free_percent_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "memory_free_percent_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/memory-free-percent.tf
+++ b/memory-free-percent.tf
@@ -6,19 +6,12 @@ locals {
 }
 
 module "memory_free_percent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name             = "System - Memory Free Percent"
   query            = "avg(${var.memory_free_percent_evaluation_period}):( min:system.mem.free{${local.memory_free_percent_filter}} by {host} / avg:system.mem.total{${local.memory_free_percent_filter}} by {host} ) * 100 < ${var.memory_free_percent_critical}"
   alert_message    = "Available memory on ${var.service} Node {{host.name}} has dropped below {{threshold}} and has {{value}}% available"
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}%"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.memory_free_percent_enabled
@@ -26,9 +19,15 @@ module "memory_free_percent" {
   warning_threshold  = var.memory_free_percent_warning
   critical_threshold = var.memory_free_percent_critical
   priority           = var.memory_free_percent_priority
-  severity           = var.memory_free_percent_severity
   docs               = var.memory_free_percent_docs
   note               = var.memory_free_percent_note
-  name_prefix        = var.memory_free_percent_name_prefix
-  name_suffix        = var.memory_free_percent_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/packet-in-errors.tf
+++ b/packet-in-errors.tf
@@ -1,4 +1,4 @@
-  # system.net.packets_in.error
+# system.net.packets_in.error
 # https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/
 
 locals {
@@ -9,20 +9,13 @@ locals {
 }
 
 module "packets_in_errors" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
-  name             = "System - Packet In Errors"
+  name = "System - Packet In Errors"
   # +1000 helps out filtering low packet rates, this prevents a handful of packet errors to skew the percentage when for example only 100 packets are received/sent
   query            = "avg(${var.packets_in_errors_evaluation_period}):100 * max:system.net.packets_in.error{${local.packets_in_errors_filter}} by {host} / ( max:system.net.packets_in.count{${local.packets_in_errors_filter}} by {host} + 1000 ) > ${var.packets_in_errors_critical}"
   alert_message    = "High rate of packet-in errors on ${var.service} Node {{host.name}} ({{value}} %)"
   recovery_message = "Packet-in error rate on ${var.service} Node {{host.name}} Recovered ({{value}} %)"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.packets_in_errors_enabled
@@ -30,9 +23,15 @@ module "packets_in_errors" {
   warning_threshold  = var.packets_in_errors_warning
   critical_threshold = var.packets_in_errors_critical
   priority           = var.packets_in_errors_priority
-  severity           = var.packets_in_errors_severity
   docs               = var.packets_in_errors_docs
   note               = var.packets_in_errors_note
-  name_prefix        = var.packets_in_errors_name_prefix
-  name_suffix        = var.packets_in_errors_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/packet-out-errors.tf
+++ b/packet-out-errors.tf
@@ -6,20 +6,13 @@ locals {
 }
 
 module "packets_out_errors" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
-  name             = "System - Packet Out Errors"
+  name = "System - Packet Out Errors"
   # +1000 helps out filtering low packet rates, this prevents a handful of packet errors to skew the percentage when for example only 100 packets are received/sent
   query            = "avg(${var.packets_out_errors_evaluation_period}):100 * max:system.net.packets_out.error{${local.packets_out_errors_filter}} by {host} / ( max:system.net.packets_out.count{${local.packets_out_errors_filter}} by {host} + 1000 ) > ${var.packets_out_errors_critical}"
   alert_message    = "High rate of packet-out errors on ${var.service} Node {{host.name}} ({{value}} %)"
   recovery_message = "Packet-out error rate on ${var.service} Node {{host.name}} Recovered ({{value}} %)"
-
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
 
   # monitor level vars
   enabled            = var.packets_out_errors_enabled
@@ -27,9 +20,15 @@ module "packets_out_errors" {
   warning_threshold  = var.packets_out_errors_warning
   critical_threshold = var.packets_out_errors_critical
   priority           = var.packets_out_errors_priority
-  severity           = var.packets_out_errors_severity
   docs               = var.packets_out_errors_docs
   note               = var.packets_out_errors_note
-  name_prefix        = var.packets_out_errors_name_prefix
-  name_suffix        = var.packets_out_errors_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/packets-in-errors-variables.tf
+++ b/packets-in-errors-variables.tf
@@ -20,11 +20,6 @@ variable "packets_in_errors_evaluation_period" {
   default = "last_15m"
 }
 
-variable "packets_in_errors_severity" {
-  type    = string
-  default = "minor"
-}
-
 variable "packets_in_errors_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "packets_in_errors_alerting_enabled" {
   default = true
 }
 
-variable "packets_in_errors_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "packets_in_errors_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "packets_in_errors_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/packets-out-errors-variables.tf
+++ b/packets-out-errors-variables.tf
@@ -20,11 +20,6 @@ variable "packets_out_errors_evaluation_period" {
   default = "last_15m"
 }
 
-variable "packets_out_errors_severity" {
-  type    = string
-  default = "minor"
-}
-
 variable "packets_out_errors_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "packets_out_errors_alerting_enabled" {
   default = true
 }
 
-variable "packets_out_errors_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "packets_out_errors_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "packets_out_errors_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 2.21"
+      version = "~> 2.21"
     }
   }
 }

--- a/reboot-variables.tf
+++ b/reboot-variables.tf
@@ -3,11 +3,6 @@ variable "reboot_enabled" {
   default = true
 }
 
-variable "reboot_severity" {
-  type    = string
-  default = "critical"
-}
-
 variable "reboot_note" {
   type    = string
   default = ""
@@ -28,19 +23,9 @@ variable "reboot_alerting_enabled" {
   default = true
 }
 
-variable "reboot_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "reboot_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "reboot_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/reboot.tf
+++ b/reboot.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "reboot" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name                = "Sytem - Reboot detected"
   query               = "min(last_5m):derivative(max:system.uptime{${local.reboot_filter}} by {host}) < 0"
@@ -14,22 +14,21 @@ module "reboot" {
   recovery_message    = ""
   require_full_window = false
 
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-
   # monitor level vars
   enabled          = var.reboot_enabled
   alerting_enabled = var.reboot_alerting_enabled
   # no warning
   critical_threshold = 0
   priority           = var.reboot_priority
-  severity           = var.reboot_severity
   docs               = var.reboot_docs
   note               = var.reboot_note
-  name_prefix        = var.reboot_name_prefix
-  name_suffix        = var.reboot_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/required-services-variables.tf
+++ b/required-services-variables.tf
@@ -13,11 +13,6 @@ variable "required_services_default_freshness_duration" {
   default = "5m"
 }
 
-variable "required_services_default_severity" {
-  type    = string
-  default = "major"
-}
-
 variable "required_services_default_note" {
   type    = string
   default = ""
@@ -38,19 +33,9 @@ variable "required_services_alerting_enabled" {
   default = true
 }
 
-variable "required_services_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "required_services_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "required_services_default_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 2
 }

--- a/required-services.tf
+++ b/required-services.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "required_services" {
-  source   = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source   = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
   for_each = var.required_services_config
 
   name                = "System - ${upper(substr(each.key, 0, 1))}${substr(each.key, 1, length(each.key) - 1)} service not running"
@@ -16,22 +16,21 @@ module "required_services" {
   recovery_message    = "${each.key} is back on ${var.service} Node {{host.name}}"
   require_full_window = false
 
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-
   # monitor level vars
   enabled          = var.required_services_enabled
   alerting_enabled = var.required_services_alerting_enabled
   # no warning
   critical_threshold = lookup(each.value, "process_count", 1)
   priority           = var.required_services_default_priority
-  severity           = var.required_services_default_severity
   note               = var.required_services_default_note
   docs               = var.required_services_default_docs
-  name_prefix        = var.required_services_name_prefix
-  name_suffix        = var.required_services_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/swap-variables.tf
+++ b/swap-variables.tf
@@ -20,11 +20,6 @@ variable "swap_percent_free_evaluation_period" {
   default = "last_5m"
 }
 
-variable "swap_percent_free_severity" {
-  type    = string
-  default = "minor"
-}
-
 variable "swap_percent_free_note" {
   type    = string
   default = ""
@@ -45,19 +40,9 @@ variable "swap_percent_free_alerting_enabled" {
   default = true
 }
 
-variable "swap_percent_free_name_prefix" {
-  type    = string
-  default = ""
-}
-
-variable "swap_percent_free_name_suffix" {
-  type    = string
-  default = ""
-}
-
 variable "swap_percent_free_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = null
+  default = 3
 }

--- a/swap.tf
+++ b/swap.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "swap_percent_free" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.2.rc1"
 
   name                = "System - Swap percent free"
   query               = "avg(${var.swap_percent_free_evaluation_period}):min:system.swap.pct_free{${local.swap_percent_free_filter}} by {host} * 100 < ${var.swap_percent_free_critical}"
@@ -14,22 +14,21 @@ module "swap_percent_free" {
   recovery_message    = "Swap memory percent free on ${var.service} Node {{host.name}} has recovered ({{value}}%))"
   require_full_window = false
 
-  # module level vars
-  env                  = var.alert_env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-
   # monitor level vars
   enabled            = var.swap_percent_free_enabled
   alerting_enabled   = var.swap_percent_free_alerting_enabled
   warning_threshold  = var.swap_percent_free_warning
   critical_threshold = var.swap_percent_free_critical
   priority           = var.swap_percent_free_priority
-  severity           = var.swap_percent_free_severity
   docs               = var.swap_percent_free_docs
   note               = var.swap_percent_free_note
-  name_prefix        = var.swap_percent_free_name_prefix
-  name_suffix        = var.swap_percent_free_name_suffix
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }


### PR DESCRIPTION
Changes:
- Update to generic monitor 0.6.2
- Remove support for severity tags
- Added default priorities
- Moved monitor level block before module level block
- Added pre-commit
