### PR TITLE
Added monitors for memory usable and disk used if other data is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ Query:
 avg(${var.dd_agent_evaluation_period}):avg:datadog.agent.running{${local.dd_agent_filter}} by {host} < 1
 ```
 
-| variable                   | default                                  | required | description                      |
-|----------------------------|------------------------------------------|----------|----------------------------------|
-| dd_agent_enabled           | True                                     | No       |                                  |
-| dd_agent_evaluation_period | last_15m                                 | No       |                                  |
-| dd_agent_note              | ""                                       | No       |                                  |
-| dd_agent_docs              | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
-| dd_agent_filter_override   | ""                                       | No       |                                  |
-| dd_agent_alerting_enabled  | True                                     | No       |                                  |
-| dd_agent_data_priority     | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| variable                               | default                                  | required | description                      |
+|----------------------------------------|------------------------------------------|----------|----------------------------------|
+| dd_agent_enabled                       | True                                     | No       |                                  |
+| dd_agent_evaluation_period             | last_15m                                 | No       |                                  |
+| dd_agent_note                          | ""                                       | No       |                                  |
+| dd_agent_docs                          | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
+| dd_agent_filter_override               | ""                                       | No       |                                  |
+| dd_agent_alerting_enabled              | True                                     | No       |                                  |
+| dd_agent_priority                      | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| dd_agent_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Required Services
@@ -86,16 +87,17 @@ Query:
 processes('${each.key}').over('tag:xxx').by('host').rollup('count').last('${lookup(each.value, "freshness_duration", var.required_services_default_freshness_duration)}') < ${lookup(each.value, "process_count", 1)}
 ```
 
-| variable                                     | default  | required | description                      |
-|----------------------------------------------|----------|----------|----------------------------------|
-| required_services_enabled                    | True     | No       |                                  |
-| required_services_config                     | {}       | No       |                                  |
-| required_services_default_freshness_duration | 5m       | No       |                                  |
-| required_services_default_note               | ""       | No       |                                  |
-| required_services_default_docs               | ""       | No       |                                  |
-| required_services_filter_override            | ""       | No       |                                  |
-| required_services_alerting_enabled           | True     | No       |                                  |
-| required_services_default_priority           | 2        | No       | Number from 1 (high) to 5 (low). |
+| variable                                        | default  | required | description                      |
+|-------------------------------------------------|----------|----------|----------------------------------|
+| required_services_enabled                       | True     | No       |                                  |
+| required_services_config                        | {}       | No       |                                  |
+| required_services_default_freshness_duration    | 5m       | No       |                                  |
+| required_services_default_note                  | ""       | No       |                                  |
+| required_services_default_docs                  | ""       | No       |                                  |
+| required_services_filter_override               | ""       | No       |                                  |
+| required_services_alerting_enabled              | True     | No       |                                  |
+| required_services_default_priority              | 2        | No       | Number from 1 (high) to 5 (low). |
+| required_services_notification_channel_override | ""       | No       |                                  |
 
 
 ## Bytes Sent
@@ -105,17 +107,18 @@ Query:
 avg(last_30m):avg:system.net.bytes_sent{tag:xxx} by {host} > 5000000
 ```
 
-| variable                     | default  | required | description                      |
-|------------------------------|----------|----------|----------------------------------|
-| bytes_sent_enabled           | True     | No       |                                  |
-| bytes_sent_warning           | 4000000  | No       |                                  |
-| bytes_sent_critical          | 5000000  | No       |                                  |
-| bytes_sent_evaluation_period | last_30m | No       |                                  |
-| bytes_sent_note              | ""       | No       |                                  |
-| bytes_sent_docs              | ""       | No       |                                  |
-| bytes_sent_filter_override   | ""       | No       |                                  |
-| bytes_sent_alerting_enabled  | True     | No       |                                  |
-| bytes_sent_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
+| variable                                 | default  | required | description                      |
+|------------------------------------------|----------|----------|----------------------------------|
+| bytes_sent_enabled                       | True     | No       |                                  |
+| bytes_sent_warning                       | 4000000  | No       |                                  |
+| bytes_sent_critical                      | 5000000  | No       |                                  |
+| bytes_sent_evaluation_period             | last_30m | No       |                                  |
+| bytes_sent_note                          | ""       | No       |                                  |
+| bytes_sent_docs                          | ""       | No       |                                  |
+| bytes_sent_filter_override               | ""       | No       |                                  |
+| bytes_sent_alerting_enabled              | True     | No       |                                  |
+| bytes_sent_priority                      | 3        | No       | Number from 1 (high) to 5 (low). |
+| bytes_sent_notification_channel_override | ""       | No       |                                  |
 
 
 ## Disk Free Percent
@@ -125,34 +128,41 @@ Query:
 avg(last_5m):100 * min:system.disk.free{tag:xxx} by {host,device} / min:system.disk.total{tag:xxx} by {host,device} < 10
 ```
 
-| variable                            | default  | required | description                      |
-|-------------------------------------|----------|----------|----------------------------------|
-| disk_free_percent_enabled           | True     | No       |                                  |
-| disk_free_percent_warning           | 20       | No       |                                  |
-| disk_free_percent_critical          | 10       | No       |                                  |
-| disk_free_percent_evaluation_period | last_5m  | No       |                                  |
-| disk_free_percent_note              | ""       | No       |                                  |
-| disk_free_percent_docs              | ""       | No       |                                  |
-| disk_free_percent_filter_override   | ""       | No       |                                  |
-| disk_free_percent_alerting_enabled  | True     | No       |                                  |
-| disk_free_percent_priority          | 1        | No       | Number from 1 (high) to 5 (low). |
+| variable                                        | default  | required | description                      |
+|-------------------------------------------------|----------|----------|----------------------------------|
+| disk_free_percent_enabled                       | True     | No       |                                  |
+| disk_free_percent_warning                       | 20       | No       |                                  |
+| disk_free_percent_critical                      | 10       | No       |                                  |
+| disk_free_percent_evaluation_period             | last_5m  | No       |                                  |
+| disk_free_percent_note                          | ""       | No       |                                  |
+| disk_free_percent_docs                          | ""       | No       |                                  |
+| disk_free_percent_filter_override               | ""       | No       |                                  |
+| disk_free_percent_alerting_enabled              | True     | No       |                                  |
+| disk_free_percent_priority                      | 1        | No       | Number from 1 (high) to 5 (low). |
+| disk_free_percent_notification_channel_override | ""       | No       |                                  |
 
 
 ## Packets Out Errors
 
 Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/
 
-| variable                             | default                                  | required | description                      |
-|--------------------------------------|------------------------------------------|----------|----------------------------------|
-| packets_out_errors_enabled           | True                                     | No       |                                  |
-| packets_out_errors_warning           | 0.5                                      | No       |                                  |
-| packets_out_errors_critical          | 1                                        | No       |                                  |
-| packets_out_errors_evaluation_period | last_15m                                 | No       |                                  |
-| packets_out_errors_note              | ""                                       | No       |                                  |
-| packets_out_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
-| packets_out_errors_filter_override   | ""                                       | No       |                                  |
-| packets_out_errors_alerting_enabled  | True                                     | No       |                                  |
-| packets_out_errors_priority          | 3                                        | No       | Number from 1 (high) to 5 (low). |
+Query:
+```terraform
+avg(last_15m):100 * max:system.net.packets_out.error{tag:xxx} by {host} / ( max:system.net.packets_out.count{tag:xxx} by {host} + 1000 ) > 1
+```
+
+| variable                                         | default                                  | required | description                      |
+|--------------------------------------------------|------------------------------------------|----------|----------------------------------|
+| packets_out_errors_enabled                       | True                                     | No       |                                  |
+| packets_out_errors_warning                       | 0.5                                      | No       |                                  |
+| packets_out_errors_critical                      | 1                                        | No       |                                  |
+| packets_out_errors_evaluation_period             | last_15m                                 | No       |                                  |
+| packets_out_errors_note                          | ""                                       | No       |                                  |
+| packets_out_errors_docs                          | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
+| packets_out_errors_filter_override               | ""                                       | No       |                                  |
+| packets_out_errors_alerting_enabled              | True                                     | No       |                                  |
+| packets_out_errors_priority                      | 3                                        | No       | Number from 1 (high) to 5 (low). |
+| packets_out_errors_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Memory Free Percent
@@ -162,33 +172,35 @@ Query:
 avg(last_5m):min:system.mem.pct_usable{tag:xxx} by {host} < 10
 ```
 
-| variable                              | default  | required | description                      |
-|---------------------------------------|----------|----------|----------------------------------|
-| memory_free_percent_enabled           | True     | No       |                                  |
-| memory_free_percent_warning           | 20       | No       |                                  |
-| memory_free_percent_critical          | 10       | No       |                                  |
-| memory_free_percent_evaluation_period | last_5m  | No       |                                  |
-| memory_free_percent_note              | ""       | No       |                                  |
-| memory_free_percent_docs              | ""       | No       |                                  |
-| memory_free_percent_filter_override   | ""       | No       |                                  |
-| memory_free_percent_alerting_enabled  | True     | No       |                                  |
-| memory_free_percent_priority          | 2        | No       | Number from 1 (high) to 5 (low). |
+| variable                                          | default  | required | description                      |
+|---------------------------------------------------|----------|----------|----------------------------------|
+| memory_free_percent_enabled                       | True     | No       |                                  |
+| memory_free_percent_warning                       | 20       | No       |                                  |
+| memory_free_percent_critical                      | 10       | No       |                                  |
+| memory_free_percent_evaluation_period             | last_5m  | No       |                                  |
+| memory_free_percent_note                          | ""       | No       |                                  |
+| memory_free_percent_docs                          | ""       | No       |                                  |
+| memory_free_percent_filter_override               | ""       | No       |                                  |
+| memory_free_percent_alerting_enabled              | True     | No       |                                  |
+| memory_free_percent_priority                      | 2        | No       | Number from 1 (high) to 5 (low). |
+| memory_free_percent_notification_channel_override | ""       | No       |                                  |
 
 
 ## Datadog Agent Data
 
 Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event
 
-| variable                            | default                                  | required | description                      |
-|-------------------------------------|------------------------------------------|----------|----------------------------------|
-| dd_agent_data_enabled               | True                                     | No       |                                  |
-| dd_agent_data_note                  | ""                                       | No       |                                  |
-| dd_agent_data_docs                  | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
-| dd_agent_data_filter_override       | ""                                       | No       |                                  |
-| dd_agent_data_include_tags_override | None                                     | No       |                                  |
-| dd_agent_data_exclude_tags_override | None                                     | No       |                                  |
-| dd_agent_data_alerting_enabled      | True                                     | No       |                                  |
-| dd_agent_priority                   | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| variable                                    | default                                  | required | description                      |
+|---------------------------------------------|------------------------------------------|----------|----------------------------------|
+| dd_agent_data_enabled                       | True                                     | No       |                                  |
+| dd_agent_data_note                          | ""                                       | No       |                                  |
+| dd_agent_data_docs                          | Not getting monitoring data could mean anything, best is to assume the host is down and consider this a major event | No       |                                  |
+| dd_agent_data_filter_override               | ""                                       | No       |                                  |
+| dd_agent_data_include_tags_override         | None                                     | No       |                                  |
+| dd_agent_data_exclude_tags_override         | None                                     | No       |                                  |
+| dd_agent_data_alerting_enabled              | True                                     | No       |                                  |
+| dd_agent_data_priority                      | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| dd_agent_data_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Disk Free Bytes
@@ -198,34 +210,41 @@ Query:
 avg(last_5m):min:system.disk.free{tag:xxx} by {host,device} < 10000000000
 ```
 
-| variable                          | default     | required | description                      |
-|-----------------------------------|-------------|----------|----------------------------------|
-| disk_free_bytes_enabled           | False       | No       |                                  |
-| disk_free_bytes_warning           | 20000000000 | No       |                                  |
-| disk_free_bytes_critical          | 10000000000 | No       |                                  |
-| disk_free_bytes_evaluation_period | last_5m     | No       |                                  |
-| disk_free_bytes_note              | ""          | No       |                                  |
-| disk_free_bytes_docs              | ""          | No       |                                  |
-| disk_free_bytes_filter_override   | ""          | No       |                                  |
-| disk_free_bytes_alerting_enabled  | True        | No       |                                  |
-| disk_free_bytes_priority          | 1           | No       | Number from 1 (high) to 5 (low). |
+| variable                                      | default     | required | description                      |
+|-----------------------------------------------|-------------|----------|----------------------------------|
+| disk_free_bytes_enabled                       | False       | No       |                                  |
+| disk_free_bytes_warning                       | 20000000000 | No       |                                  |
+| disk_free_bytes_critical                      | 10000000000 | No       |                                  |
+| disk_free_bytes_evaluation_period             | last_5m     | No       |                                  |
+| disk_free_bytes_note                          | ""          | No       |                                  |
+| disk_free_bytes_docs                          | ""          | No       |                                  |
+| disk_free_bytes_filter_override               | ""          | No       |                                  |
+| disk_free_bytes_alerting_enabled              | True        | No       |                                  |
+| disk_free_bytes_priority                      | 1           | No       | Number from 1 (high) to 5 (low). |
+| disk_free_bytes_notification_channel_override | ""          | No       |                                  |
 
 
 ## Packets In Errors
 
 Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/
 
-| variable                            | default                                  | required | description                      |
-|-------------------------------------|------------------------------------------|----------|----------------------------------|
-| packets_in_errors_enabled           | True                                     | No       |                                  |
-| packets_in_errors_warning           | 0.5                                      | No       |                                  |
-| packets_in_errors_critical          | 1                                        | No       |                                  |
-| packets_in_errors_evaluation_period | last_15m                                 | No       |                                  |
-| packets_in_errors_note              | ""                                       | No       |                                  |
-| packets_in_errors_docs              | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
-| packets_in_errors_filter_override   | ""                                       | No       |                                  |
-| packets_in_errors_alerting_enabled  | True                                     | No       |                                  |
-| packets_in_errors_priority          | 3                                        | No       | Number from 1 (high) to 5 (low). |
+Query:
+```terraform
+avg(last_15m):100 * max:system.net.packets_in.error{tag:xxx} by {host} / ( max:system.net.packets_in.count{tag:xxx} by {host} + 1000 ) > 1
+```
+
+| variable                                        | default                                  | required | description                      |
+|-------------------------------------------------|------------------------------------------|----------|----------------------------------|
+| packets_in_errors_enabled                       | True                                     | No       |                                  |
+| packets_in_errors_warning                       | 0.5                                      | No       |                                  |
+| packets_in_errors_critical                      | 1                                        | No       |                                  |
+| packets_in_errors_evaluation_period             | last_15m                                 | No       |                                  |
+| packets_in_errors_note                          | ""                                       | No       |                                  |
+| packets_in_errors_docs                          | Packet errors can severely degrade network performance. A good article about it is found here: https://netcraftsmen.com/understanding-interface-errors-and-tcp-performance/ | No       |                                  |
+| packets_in_errors_filter_override               | ""                                       | No       |                                  |
+| packets_in_errors_alerting_enabled              | True                                     | No       |                                  |
+| packets_in_errors_priority                      | 3                                        | No       | Number from 1 (high) to 5 (low). |
+| packets_in_errors_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Swap
@@ -235,17 +254,18 @@ Query:
 avg(${var.swap_percent_free_evaluation_period}):min:system.swap.pct_free{${local.swap_percent_free_filter}} by {host} * 100 < ${var.swap_percent_free_critical}
 ```
 
-| variable                            | default  | required | description                      |
-|-------------------------------------|----------|----------|----------------------------------|
-| swap_percent_free_enabled           | True     | No       |                                  |
-| swap_percent_free_warning           | 15       | No       |                                  |
-| swap_percent_free_critical          | 10       | No       |                                  |
-| swap_percent_free_evaluation_period | last_5m  | No       |                                  |
-| swap_percent_free_note              | ""       | No       |                                  |
-| swap_percent_free_docs              | ""       | No       |                                  |
-| swap_percent_free_filter_override   | ""       | No       |                                  |
-| swap_percent_free_alerting_enabled  | True     | No       |                                  |
-| swap_percent_free_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
+| variable                                        | default  | required | description                      |
+|-------------------------------------------------|----------|----------|----------------------------------|
+| swap_percent_free_enabled                       | True     | No       |                                  |
+| swap_percent_free_warning                       | 15       | No       |                                  |
+| swap_percent_free_critical                      | 10       | No       |                                  |
+| swap_percent_free_evaluation_period             | last_5m  | No       |                                  |
+| swap_percent_free_note                          | ""       | No       |                                  |
+| swap_percent_free_docs                          | ""       | No       |                                  |
+| swap_percent_free_filter_override               | ""       | No       |                                  |
+| swap_percent_free_alerting_enabled              | True     | No       |                                  |
+| swap_percent_free_priority                      | 3        | No       | Number from 1 (high) to 5 (low). |
+| swap_percent_free_notification_channel_override | ""       | No       |                                  |
 
 
 ## Memory Free Bytes
@@ -255,17 +275,18 @@ Query:
 avg(last_5m):min:system.mem.usable{tag:xxx} by {host} < 1000000000
 ```
 
-| variable                            | default    | required | description                                                                          |
-|-------------------------------------|------------|----------|--------------------------------------------------------------------------------------|
-| memory_free_bytes_enabled           | False      | No       | Memory free based on absolute values. Disabled by default to use memory_free_percent |
-| memory_free_bytes_warning           | 2000000000 | No       |                                                                                      |
-| memory_free_bytes_critical          | 1000000000 | No       |                                                                                      |
-| memory_free_bytes_evaluation_period | last_5m    | No       |                                                                                      |
-| memory_free_bytes_note              | ""         | No       |                                                                                      |
-| memory_free_bytes_docs              | ""         | No       |                                                                                      |
-| memory_free_bytes_filter_override   | ""         | No       |                                                                                      |
-| memory_free_bytes_alerting_enabled  | True       | No       |                                                                                      |
-| memory_free_bytes_priority          | 2          | No       | Number from 1 (high) to 5 (low).                                                     |
+| variable                                        | default    | required | description                                                                          |
+|-------------------------------------------------|------------|----------|--------------------------------------------------------------------------------------|
+| memory_free_bytes_enabled                       | False      | No       | Memory free based on absolute values. Disabled by default to use memory_free_percent |
+| memory_free_bytes_warning                       | 2000000000 | No       |                                                                                      |
+| memory_free_bytes_critical                      | 1000000000 | No       |                                                                                      |
+| memory_free_bytes_evaluation_period             | last_5m    | No       |                                                                                      |
+| memory_free_bytes_note                          | ""         | No       |                                                                                      |
+| memory_free_bytes_docs                          | ""         | No       |                                                                                      |
+| memory_free_bytes_filter_override               | ""         | No       |                                                                                      |
+| memory_free_bytes_alerting_enabled              | True       | No       |                                                                                      |
+| memory_free_bytes_priority                      | 2          | No       | Number from 1 (high) to 5 (low).                                                     |
+| memory_free_bytes_notification_channel_override | ""         | No       |                                                                                      |
 
 
 ## Bytes Received
@@ -275,17 +296,18 @@ Query:
 avg(last_30m):avg:system.net.bytes_rcvd{tag:xxx} by {host} > 5000000
 ```
 
-| variable                         | default  | required | description                      |
-|----------------------------------|----------|----------|----------------------------------|
-| bytes_received_enabled           | True     | No       |                                  |
-| bytes_received_warning           | 4000000  | No       |                                  |
-| bytes_received_critical          | 5000000  | No       |                                  |
-| bytes_received_evaluation_period | last_30m | No       |                                  |
-| bytes_received_note              | ""       | No       |                                  |
-| bytes_received_docs              | ""       | No       |                                  |
-| bytes_received_filter_override   | ""       | No       |                                  |
-| bytes_received_alerting_enabled  | True     | No       |                                  |
-| bytes_received_priority          | 3        | No       | Number from 1 (high) to 5 (low). |
+| variable                                     | default  | required | description                      |
+|----------------------------------------------|----------|----------|----------------------------------|
+| bytes_received_enabled                       | True     | No       |                                  |
+| bytes_received_warning                       | 4000000  | No       |                                  |
+| bytes_received_critical                      | 5000000  | No       |                                  |
+| bytes_received_evaluation_period             | last_30m | No       |                                  |
+| bytes_received_note                          | ""       | No       |                                  |
+| bytes_received_docs                          | ""       | No       |                                  |
+| bytes_received_filter_override               | ""       | No       |                                  |
+| bytes_received_alerting_enabled              | True     | No       |                                  |
+| bytes_received_priority                      | 3        | No       | Number from 1 (high) to 5 (low). |
+| bytes_received_notification_channel_override | ""       | No       |                                  |
 
 
 ## Disk Iowait
@@ -297,17 +319,18 @@ Query:
 avg(${var.disk_io_wait_evaluation_period}):avg:system.cpu.iowait{${local.disk_io_wait_filter}} by {host} > ${var.disk_io_wait_critical}
 ```
 
-| variable                       | default                                  | required | description                      |
-|--------------------------------|------------------------------------------|----------|----------------------------------|
-| disk_io_wait_enabled           | True                                     | No       |                                  |
-| disk_io_wait_warning           | 80                                       | No       |                                  |
-| disk_io_wait_critical          | 95                                       | No       |                                  |
-| disk_io_wait_evaluation_period | last_30m                                 | No       |                                  |
-| disk_io_wait_note              | ""                                       | No       |                                  |
-| disk_io_wait_docs              | The CPU is mainly waiting for data to be written on disk. This means in general that application running on this machine is stalled | No       |                                  |
-| disk_io_wait_filter_override   | ""                                       | No       |                                  |
-| disk_io_wait_alerting_enabled  | True                                     | No       |                                  |
-| disk_io_wait_priority          | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| variable                                   | default                                  | required | description                      |
+|--------------------------------------------|------------------------------------------|----------|----------------------------------|
+| disk_io_wait_enabled                       | True                                     | No       |                                  |
+| disk_io_wait_warning                       | 80                                       | No       |                                  |
+| disk_io_wait_critical                      | 95                                       | No       |                                  |
+| disk_io_wait_evaluation_period             | last_30m                                 | No       |                                  |
+| disk_io_wait_note                          | ""                                       | No       |                                  |
+| disk_io_wait_docs                          | The CPU is mainly waiting for data to be written on disk. This means in general that application running on this machine is stalled | No       |                                  |
+| disk_io_wait_filter_override               | ""                                       | No       |                                  |
+| disk_io_wait_alerting_enabled              | True                                     | No       |                                  |
+| disk_io_wait_priority                      | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| disk_io_wait_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Reboot
@@ -317,14 +340,15 @@ Query:
 min(last_5m):derivative(max:system.uptime{tag:xxx} by {host}) < 0
 ```
 
-| variable                | default  | required | description                      |
-|-------------------------|----------|----------|----------------------------------|
-| reboot_enabled          | True     | No       |                                  |
-| reboot_note             | ""       | No       |                                  |
-| reboot_docs             | ""       | No       |                                  |
-| reboot_filter_override  | ""       | No       |                                  |
-| reboot_alerting_enabled | True     | No       |                                  |
-| reboot_priority         | 3        | No       | Number from 1 (high) to 5 (low). |
+| variable                             | default  | required | description                      |
+|--------------------------------------|----------|----------|----------------------------------|
+| reboot_enabled                       | True     | No       |                                  |
+| reboot_note                          | ""       | No       |                                  |
+| reboot_docs                          | ""       | No       |                                  |
+| reboot_filter_override               | ""       | No       |                                  |
+| reboot_alerting_enabled              | True     | No       |                                  |
+| reboot_priority                      | 3        | No       | Number from 1 (high) to 5 (low). |
+| reboot_notification_channel_override | ""       | No       |                                  |
 
 
 ## CPU
@@ -334,17 +358,18 @@ Query:
 avg(last_30m):avg:system.cpu.user{tag:xxx} by {host} + avg:system.cpu.system{tag:xxx} by {host} > 95
 ```
 
-| variable              | default  | required | description                      |
-|-----------------------|----------|----------|----------------------------------|
-| cpu_enabled           | True     | No       |                                  |
-| cpu_warning           | 80       | No       |                                  |
-| cpu_critical          | 95       | No       |                                  |
-| cpu_evaluation_period | last_30m | No       |                                  |
-| cpu_note              | ""       | No       |                                  |
-| cpu_docs              | ""       | No       |                                  |
-| cpu_filter_override   | ""       | No       |                                  |
-| cpu_alerting_enabled  | True     | No       |                                  |
-| cpu_priority          | 2        | No       | Number from 1 (high) to 5 (low). |
+| variable                          | default  | required | description                      |
+|-----------------------------------|----------|----------|----------------------------------|
+| cpu_enabled                       | True     | No       |                                  |
+| cpu_warning                       | 80       | No       |                                  |
+| cpu_critical                      | 95       | No       |                                  |
+| cpu_evaluation_period             | last_30m | No       |                                  |
+| cpu_note                          | ""       | No       |                                  |
+| cpu_docs                          | ""       | No       |                                  |
+| cpu_filter_override               | ""       | No       |                                  |
+| cpu_alerting_enabled              | True     | No       |                                  |
+| cpu_priority                      | 2        | No       | Number from 1 (high) to 5 (low). |
+| cpu_notification_channel_override | ""       | No       |                                  |
 
 
 ## Module Variables

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Monitors:
   * [Datadog Agent](#datadog-agent)
   * [Required Services](#required-services)
   * [Bytes Sent](#bytes-sent)
+  * [Disk In Use Percentage](#disk-in-use-percentage)
   * [Disk Free Percent](#disk-free-percent)
   * [Packets Out Errors](#packets-out-errors)
   * [Memory Free Percent](#memory-free-percent)
@@ -122,6 +123,34 @@ avg(last_30m):avg:system.net.bytes_sent{tag:xxx} by {host} > 5000000
 | bytes_sent_notification_channel_override | ""       | No       |                                  |
 
 
+## Disk In Use Percentage
+
+Default disabled, only use when disk_free_percent is not giving results
+
+Query:
+```terraform
+avg(last_5m):min:system.disk.in_use{tag:xxx} by {host} * 100 > 90
+```
+
+| variable                                             | default                                  | required | description                      |
+|------------------------------------------------------|------------------------------------------|----------|----------------------------------|
+| disk_in_use_percentage_enabled                       | False                                    | No       |                                  |
+| disk_in_use_percentage_warning                       | 80                                       | No       |                                  |
+| disk_in_use_percentage_critical                      | 90                                       | No       |                                  |
+| disk_in_use_percentage_evaluation_period             | last_5m                                  | No       |                                  |
+| disk_in_use_percentage_note                          | system.disk.in_use is actually a fraction, we've multiplied it by 100 to make it a percentage | No       |                                  |
+| disk_in_use_percentage_docs                          | Default disabled, only use when disk_free_percent is not giving results | No       |                                  |
+| disk_in_use_percentage_filter_override               | ""                                       | No       |                                  |
+| disk_in_use_percentage_alerting_enabled              | True                                     | No       |                                  |
+| disk_in_use_percentage_no_data_timeframe             | None                                     | No       |                                  |
+| disk_in_use_percentage_notify_no_data                | False                                    | No       |                                  |
+| disk_in_use_percentage_ok_threshold                  | None                                     | No       |                                  |
+| disk_in_use_percentage_name_prefix                   | ""                                       | No       |                                  |
+| disk_in_use_percentage_name_suffix                   | ""                                       | No       |                                  |
+| disk_in_use_percentage_priority                      | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| disk_in_use_percentage_notification_channel_override | ""                                       | No       |                                  |
+
+
 ## Disk Free Percent
 
 Query:
@@ -139,7 +168,7 @@ avg(last_5m):100 * min:system.disk.free{tag:xxx} by {host,device} / min:system.d
 | disk_free_percent_docs                          | ""       | No       |                                  |
 | disk_free_percent_filter_override               | ""       | No       |                                  |
 | disk_free_percent_alerting_enabled              | True     | No       |                                  |
-| disk_free_percent_priority                      | 1        | No       | Number from 1 (high) to 5 (low). |
+| disk_free_percent_priority                      | 2        | No       | Number from 1 (high) to 5 (low). |
 | disk_free_percent_notification_channel_override | ""       | No       |                                  |
 
 
@@ -221,7 +250,7 @@ avg(last_5m):min:system.disk.free{tag:xxx} by {host,device} < 10000000000
 | disk_free_bytes_docs                          | ""          | No       |                                  |
 | disk_free_bytes_filter_override               | ""          | No       |                                  |
 | disk_free_bytes_alerting_enabled              | True        | No       |                                  |
-| disk_free_bytes_priority                      | 1           | No       | Number from 1 (high) to 5 (low). |
+| disk_free_bytes_priority                      | 2           | No       | Number from 1 (high) to 5 (low). |
 | disk_free_bytes_notification_channel_override | ""          | No       |                                  |
 
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Monitors:
   * [Swap](#swap)
   * [Memory Free Bytes](#memory-free-bytes)
   * [Bytes Received](#bytes-received)
+  * [Memory Usable Percent](#memory-usable-percent)
   * [Disk Iowait](#disk-iowait)
   * [Reboot](#reboot)
   * [CPU](#cpu)
@@ -308,6 +309,34 @@ avg(last_30m):avg:system.net.bytes_rcvd{tag:xxx} by {host} > 5000000
 | bytes_received_alerting_enabled              | True     | No       |                                  |
 | bytes_received_priority                      | 3        | No       | Number from 1 (high) to 5 (low). |
 | bytes_received_notification_channel_override | ""       | No       |                                  |
+
+
+## Memory Usable Percent
+
+This looks at system.mem.usable, only use this when memory_free_percent doesn't have data
+
+Query:
+```terraform
+avg(last_5m):100 * min:system.mem.usable{tag:xxx} by {host} / min:system.mem.total{tag:xxx} by {host} < 10
+```
+
+| variable                                            | default                                  | required | description                      |
+|-----------------------------------------------------|------------------------------------------|----------|----------------------------------|
+| memory_usable_percent_enabled                       | False                                    | No       |                                  |
+| memory_usable_percent_warning                       | 20                                       | No       |                                  |
+| memory_usable_percent_critical                      | 10                                       | No       |                                  |
+| memory_usable_percent_evaluation_period             | last_5m                                  | No       |                                  |
+| memory_usable_percent_note                          | ""                                       | No       |                                  |
+| memory_usable_percent_docs                          | This looks at system.mem.usable, only use this when memory_free_percent doesn't have data | No       |                                  |
+| memory_usable_percent_filter_override               | ""                                       | No       |                                  |
+| memory_usable_percent_alerting_enabled              | True                                     | No       |                                  |
+| memory_usable_percent_no_data_timeframe             | None                                     | No       |                                  |
+| memory_usable_percent_notify_no_data                | False                                    | No       |                                  |
+| memory_usable_percent_ok_threshold                  | None                                     | No       |                                  |
+| memory_usable_percent_name_prefix                   | ""                                       | No       |                                  |
+| memory_usable_percent_name_suffix                   | ""                                       | No       |                                  |
+| memory_usable_percent_priority                      | 2                                        | No       | Number from 1 (high) to 5 (low). |
+| memory_usable_percent_notification_channel_override | ""                                       | No       |                                  |
 
 
 ## Disk Iowait

--- a/bytes-received-variables.tf
+++ b/bytes-received-variables.tf
@@ -46,3 +46,8 @@ variable "bytes_received_priority" {
   type    = number
   default = 3
 }
+
+variable "bytes_received_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/bytes-received.tf
+++ b/bytes-received.tf
@@ -24,10 +24,11 @@ module "bytes_received" {
   notification_channel = try(coalesce(var.bytes_received_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/bytes-received.tf
+++ b/bytes-received.tf
@@ -14,20 +14,20 @@ module "bytes_received" {
   recovery_message = "Ingress traffic on ${var.service} Node {{host.name}} Recovered ({{value}})"
 
   # monitor level vars
-  enabled            = var.bytes_received_enabled
-  alerting_enabled   = var.bytes_received_alerting_enabled
-  warning_threshold  = var.bytes_received_warning
-  critical_threshold = var.bytes_received_critical
-  priority           = min(var.bytes_received_priority + var.priority_offset, 5)
-  docs               = var.bytes_received_docs
-  note               = var.bytes_received_note
+  enabled              = var.bytes_received_enabled
+  alerting_enabled     = var.bytes_received_alerting_enabled
+  warning_threshold    = var.bytes_received_warning
+  critical_threshold   = var.bytes_received_critical
+  priority             = min(var.bytes_received_priority + var.priority_offset, 5)
+  docs                 = var.bytes_received_docs
+  note                 = var.bytes_received_note
+  notification_channel = try(coalesce(var.bytes_received_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/bytes-sent-variables.tf
+++ b/bytes-sent-variables.tf
@@ -46,3 +46,8 @@ variable "bytes_sent_priority" {
   type    = number
   default = 3
 }
+
+variable "bytes_sent_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/bytes-sent.tf
+++ b/bytes-sent.tf
@@ -14,20 +14,20 @@ module "bytes_sent" {
   recovery_message = "High egress traffic on ${var.service} Node {{host.name}} Recovered ({{value}})"
 
   # monitor level vars
-  enabled            = var.bytes_sent_enabled
-  alerting_enabled   = var.bytes_sent_alerting_enabled
-  warning_threshold  = var.bytes_sent_warning
-  critical_threshold = var.bytes_sent_critical
-  priority           = min(var.bytes_sent_priority + var.priority_offset, 5)
-  docs               = var.bytes_sent_docs
-  note               = var.bytes_sent_note
+  enabled              = var.bytes_sent_enabled
+  alerting_enabled     = var.bytes_sent_alerting_enabled
+  warning_threshold    = var.bytes_sent_warning
+  critical_threshold   = var.bytes_sent_critical
+  priority             = min(var.bytes_sent_priority + var.priority_offset, 5)
+  docs                 = var.bytes_sent_docs
+  note                 = var.bytes_sent_note
+  notification_channel = try(coalesce(var.bytes_sent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/bytes-sent.tf
+++ b/bytes-sent.tf
@@ -24,10 +24,11 @@ module "bytes_sent" {
   notification_channel = try(coalesce(var.bytes_sent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/cpu-variables.tf
+++ b/cpu-variables.tf
@@ -44,3 +44,8 @@ variable "cpu_priority" {
   type    = number
   default = 2
 }
+
+variable "cpu_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/cpu.tf
+++ b/cpu.tf
@@ -24,10 +24,11 @@ module "cpu" {
   notification_channel = try(coalesce(var.cpu_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/cpu.tf
+++ b/cpu.tf
@@ -14,20 +14,20 @@ module "cpu" {
   recovery_message = "CPU usage on Vault ${var.service} {{host.name}} Recovered ({{value}} %)"
 
   # monitor level vars
-  enabled            = var.cpu_enabled
-  alerting_enabled   = var.cpu_alerting_enabled
-  warning_threshold  = var.cpu_warning
-  critical_threshold = var.cpu_critical
-  priority           = min(var.cpu_priority + var.priority_offset, 5)
-  docs               = var.cpu_docs
-  note               = var.cpu_note
+  enabled              = var.cpu_enabled
+  alerting_enabled     = var.cpu_alerting_enabled
+  warning_threshold    = var.cpu_warning
+  critical_threshold   = var.cpu_critical
+  priority             = min(var.cpu_priority + var.priority_offset, 5)
+  docs                 = var.cpu_docs
+  note                 = var.cpu_note
+  notification_channel = try(coalesce(var.cpu_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/dd-agent-data-variables.tf
+++ b/dd-agent-data-variables.tf
@@ -33,9 +33,14 @@ variable "dd_agent_data_alerting_enabled" {
   default = true
 }
 
-variable "dd_agent_priority" {
+variable "dd_agent_data_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
   default = 2
+}
+
+variable "dd_agent_data_notification_channel_override" {
+  type    = string
+  default = ""
 }

--- a/dd-agent-data.tf
+++ b/dd-agent-data.tf
@@ -25,20 +25,20 @@ module "dd_agent_data" {
   notify_no_data      = true
 
   # monitor level vars
-  enabled            = var.dd_agent_data_enabled
-  alerting_enabled   = var.dd_agent_data_alerting_enabled
-  critical_threshold = 1
-  warning_threshold  = 1
-  ok_threshold       = 1
-  priority           = min(var.dd_agent_data_priority + var.priority_offset, 5)
-  docs               = var.dd_agent_data_docs
-  note               = var.dd_agent_data_note
+  enabled              = var.dd_agent_data_enabled
+  alerting_enabled     = var.dd_agent_data_alerting_enabled
+  critical_threshold   = 1
+  warning_threshold    = 1
+  ok_threshold         = 1
+  priority             = min(var.dd_agent_data_priority + var.priority_offset, 5)
+  docs                 = var.dd_agent_data_docs
+  note                 = var.dd_agent_data_note
+  notification_channel = try(coalesce(var.dd_agent_data_notification_channel_override, var.notification_channel), "")
 
   # module level vars
   env                  = var.env
   service              = var.service
   service_display_name = var.service_display_name
-  notification_channel = var.notification_channel
   additional_tags      = var.additional_tags
   locked               = var.locked
   name_prefix          = var.name_prefix

--- a/dd-agent-variables.tf
+++ b/dd-agent-variables.tf
@@ -28,9 +28,14 @@ variable "dd_agent_alerting_enabled" {
   default = true
 }
 
-variable "dd_agent_data_priority" {
+variable "dd_agent_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
   default = 2
+}
+
+variable "dd_agent_notification_channel_override" {
+  type    = string
+  default = ""
 }

--- a/dd-agent.tf
+++ b/dd-agent.tf
@@ -17,17 +17,17 @@ module "dd_agent" {
   enabled          = var.dd_agent_enabled
   alerting_enabled = var.dd_agent_alerting_enabled
   # no warning possible
-  critical_threshold = 1
-  priority           = min(var.dd_agent_priority + var.priority_offset, 5)
-  docs               = var.dd_agent_docs
-  note               = var.dd_agent_note
+  critical_threshold   = 1
+  priority             = min(var.dd_agent_priority + var.priority_offset, 5)
+  docs                 = var.dd_agent_docs
+  note                 = var.dd_agent_note
+  notification_channel = try(coalesce(var.dd_agent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/dd-agent.tf
+++ b/dd-agent.tf
@@ -24,10 +24,11 @@ module "dd_agent" {
   notification_channel = try(coalesce(var.dd_agent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-free-bytes-variables.tf
+++ b/disk-free-bytes-variables.tf
@@ -42,7 +42,7 @@ variable "disk_free_bytes_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = 1
+  default = 2
 }
 
 variable "disk_free_bytes_notification_channel_override" {

--- a/disk-free-bytes-variables.tf
+++ b/disk-free-bytes-variables.tf
@@ -44,3 +44,8 @@ variable "disk_free_bytes_priority" {
   type    = number
   default = 1
 }
+
+variable "disk_free_bytes_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/disk-free-bytes.tf
+++ b/disk-free-bytes.tf
@@ -24,10 +24,11 @@ module "disk_free_bytes" {
   notification_channel = try(coalesce(var.disk_free_bytes_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-free-bytes.tf
+++ b/disk-free-bytes.tf
@@ -14,20 +14,20 @@ module "disk_free_bytes" {
   recovery_message = "Available disk volume {{device.name}} on ${var.service} Node {{host.name}} has recovered ( {{device.name}}  has {{value}}% available on {{host.name}} )"
 
   # monitor level vars
-  enabled            = var.disk_free_bytes_enabled
-  alerting_enabled   = var.disk_free_bytes_alerting_enabled
-  warning_threshold  = var.disk_free_bytes_warning
-  critical_threshold = var.disk_free_bytes_critical
-  priority           = min(var.disk_free_bytes_priority + var.priority_offset, 5)
-  docs               = var.disk_free_bytes_docs
-  note               = var.disk_free_bytes_note
+  enabled              = var.disk_free_bytes_enabled
+  alerting_enabled     = var.disk_free_bytes_alerting_enabled
+  warning_threshold    = var.disk_free_bytes_warning
+  critical_threshold   = var.disk_free_bytes_critical
+  priority             = min(var.disk_free_bytes_priority + var.priority_offset, 5)
+  docs                 = var.disk_free_bytes_docs
+  note                 = var.disk_free_bytes_note
+  notification_channel = try(coalesce(var.disk_free_bytes_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/disk-free-percent-variables.tf
+++ b/disk-free-percent-variables.tf
@@ -46,3 +46,8 @@ variable "disk_free_percent_priority" {
   type    = number
   default = 1
 }
+
+variable "disk_free_percent_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/disk-free-percent-variables.tf
+++ b/disk-free-percent-variables.tf
@@ -44,7 +44,7 @@ variable "disk_free_percent_priority" {
   description = "Number from 1 (high) to 5 (low)."
 
   type    = number
-  default = 1
+  default = 2
 }
 
 variable "disk_free_percent_notification_channel_override" {

--- a/disk-free-percent.tf
+++ b/disk-free-percent.tf
@@ -24,10 +24,11 @@ module "disk_free_percent" {
   notification_channel = try(coalesce(var.disk_free_percent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-free-percent.tf
+++ b/disk-free-percent.tf
@@ -14,20 +14,20 @@ module "disk_free_percent" {
   recovery_message = "Available disk volume {{device.name}} on ${var.service} Node {{host.name}} has recovered ( {{device.name}}  has {{value}}% available on {{host.name}} )"
 
   # monitor level vars
-  enabled            = var.disk_free_percent_enabled
-  alerting_enabled   = var.disk_free_percent_alerting_enabled
-  warning_threshold  = var.disk_free_percent_warning
-  critical_threshold = var.disk_free_percent_critical
-  priority           = min(var.disk_free_percent_priority + var.priority_offset, 5)
-  docs               = var.disk_free_percent_docs
-  note               = var.disk_free_percent_note
+  enabled              = var.disk_free_percent_enabled
+  alerting_enabled     = var.disk_free_percent_alerting_enabled
+  warning_threshold    = var.disk_free_percent_warning
+  critical_threshold   = var.disk_free_percent_critical
+  priority             = min(var.disk_free_percent_priority + var.priority_offset, 5)
+  docs                 = var.disk_free_percent_docs
+  note                 = var.disk_free_percent_note
+  notification_channel = try(coalesce(var.disk_free_percent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/disk-in-use-percentage-variables.tf
+++ b/disk-in-use-percentage-variables.tf
@@ -1,0 +1,78 @@
+variable "disk_in_use_percentage_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "disk_in_use_percentage_warning" {
+  type    = number
+  default = 80
+  # 80%
+}
+
+variable "disk_in_use_percentage_critical" {
+  type    = number
+  default = 90
+  # 90%
+}
+
+variable "disk_in_use_percentage_evaluation_period" {
+  type    = string
+  default = "last_5m"
+}
+
+variable "disk_in_use_percentage_note" {
+  type    = string
+  default = "system.disk.in_use is actually a fraction, we've multiplied it by 100 to make it a percentage"
+}
+
+variable "disk_in_use_percentage_docs" {
+  type    = string
+  default = "Default disabled, only use when disk_free_percent is not giving results"
+}
+
+variable "disk_in_use_percentage_filter_override" {
+  type    = string
+  default = ""
+}
+
+variable "disk_in_use_percentage_alerting_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "disk_in_use_percentage_no_data_timeframe" {
+  type    = number
+  default = null
+}
+
+variable "disk_in_use_percentage_notify_no_data" {
+  type    = bool
+  default = false
+}
+
+variable "disk_in_use_percentage_ok_threshold" {
+  type    = number
+  default = null
+}
+
+variable "disk_in_use_percentage_name_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "disk_in_use_percentage_name_suffix" {
+  type    = string
+  default = ""
+}
+
+variable "disk_in_use_percentage_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = 2
+}
+
+variable "disk_in_use_percentage_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/disk-in-use-percentage.tf
+++ b/disk-in-use-percentage.tf
@@ -1,0 +1,37 @@
+locals {
+  disk_in_use_percentage_filter = coalesce(
+    var.disk_in_use_percentage_filter_override,
+    var.filter_str
+  )
+}
+
+module "disk_in_use_percentage" {
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+
+  name  = "Disk In Use Percentage"
+  query = "avg(${var.disk_in_use_percentage_evaluation_period}):min:system.disk.in_use{${local.disk_in_use_percentage_filter}} by {host} * 100 > ${var.disk_in_use_percentage_critical}"
+
+  # alert specific configuration
+  require_full_window = true
+  alert_message       = "Disk usage on CloudAMQP Node {{host.name}} has dropped below {{threshold}} ({{value}}%) available"
+  recovery_message    = "Disk usage on CloudAMQP Node {{host.name}} has recovered ({{value}}%) available"
+
+  # monitor level vars
+  enabled              = var.disk_in_use_percentage_enabled
+  alerting_enabled     = var.disk_in_use_percentage_alerting_enabled
+  warning_threshold    = var.disk_in_use_percentage_warning
+  critical_threshold   = var.disk_in_use_percentage_critical
+  priority             = var.disk_in_use_percentage_priority
+  docs                 = var.disk_in_use_percentage_docs
+  note                 = var.disk_in_use_percentage_note
+  notification_channel = try(coalesce(var.disk_in_use_percentage_notification_channel_override, var.notification_channel), "")
+
+  # module level vars
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
+}

--- a/disk-in-use-percentage.tf
+++ b/disk-in-use-percentage.tf
@@ -21,7 +21,7 @@ module "disk_in_use_percentage" {
   alerting_enabled     = var.disk_in_use_percentage_alerting_enabled
   warning_threshold    = var.disk_in_use_percentage_warning
   critical_threshold   = var.disk_in_use_percentage_critical
-  priority             = var.disk_in_use_percentage_priority
+  priority             = min(var.disk_in_use_percentage_priority + var.priority_offset, 5)
   docs                 = var.disk_in_use_percentage_docs
   note                 = var.disk_in_use_percentage_note
   notification_channel = try(coalesce(var.disk_in_use_percentage_notification_channel_override, var.notification_channel), "")

--- a/disk-iowait-variables.tf
+++ b/disk-iowait-variables.tf
@@ -46,3 +46,8 @@ variable "disk_io_wait_priority" {
   type    = number
   default = 2
 }
+
+variable "disk_io_wait_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/disk-iowait.tf
+++ b/disk-iowait.tf
@@ -24,10 +24,11 @@ module "disk_io_wait" {
   notification_channel = try(coalesce(var.disk_io_wait_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/disk-iowait.tf
+++ b/disk-iowait.tf
@@ -14,20 +14,20 @@ module "disk_io_wait" {
   recovery_message = "IO waits for CPU on ${var.service} Node {{host.name}} Recovered ({{value}} %) "
 
   # monitor level vars
-  enabled            = var.disk_io_wait_enabled
-  alerting_enabled   = var.disk_io_wait_alerting_enabled
-  warning_threshold  = var.disk_io_wait_warning
-  critical_threshold = var.disk_io_wait_critical
-  priority           = min(var.disk_io_wait_priority + var.priority_offset, 5)
-  docs               = var.disk_io_wait_docs
-  note               = var.disk_io_wait_note
+  enabled              = var.disk_io_wait_enabled
+  alerting_enabled     = var.disk_io_wait_alerting_enabled
+  warning_threshold    = var.disk_io_wait_warning
+  critical_threshold   = var.disk_io_wait_critical
+  priority             = min(var.disk_io_wait_priority + var.priority_offset, 5)
+  docs                 = var.disk_io_wait_docs
+  note                 = var.disk_io_wait_note
+  notification_channel = try(coalesce(var.disk_io_wait_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/memory-free-bytes-variables.tf
+++ b/memory-free-bytes-variables.tf
@@ -47,3 +47,8 @@ variable "memory_free_bytes_priority" {
   type    = number
   default = 2
 }
+
+variable "memory_free_bytes_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/memory-free-bytes.tf
+++ b/memory-free-bytes.tf
@@ -24,10 +24,11 @@ module "memory_free_bytes" {
   notification_channel = try(coalesce(var.memory_free_bytes_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/memory-free-bytes.tf
+++ b/memory-free-bytes.tf
@@ -14,20 +14,20 @@ module "memory_free_bytes" {
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}"
 
   # monitor level vars
-  enabled            = var.memory_free_bytes_enabled
-  alerting_enabled   = var.memory_free_bytes_alerting_enabled
-  warning_threshold  = var.memory_free_bytes_warning
-  critical_threshold = var.memory_free_bytes_critical
-  priority           = min(var.memory_free_bytes_priority + var.priority_offset, 5)
-  docs               = var.memory_free_bytes_docs
-  note               = var.memory_free_bytes_note
+  enabled              = var.memory_free_bytes_enabled
+  alerting_enabled     = var.memory_free_bytes_alerting_enabled
+  warning_threshold    = var.memory_free_bytes_warning
+  critical_threshold   = var.memory_free_bytes_critical
+  priority             = min(var.memory_free_bytes_priority + var.priority_offset, 5)
+  docs                 = var.memory_free_bytes_docs
+  note                 = var.memory_free_bytes_note
+  notification_channel = try(coalesce(var.memory_free_bytes_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/memory-free-percent-variables.tf
+++ b/memory-free-percent-variables.tf
@@ -46,3 +46,8 @@ variable "memory_free_percent_priority" {
   type    = number
   default = 2
 }
+
+variable "memory_free_percent_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/memory-free-percent.tf
+++ b/memory-free-percent.tf
@@ -24,10 +24,11 @@ module "memory_free_percent" {
   notification_channel = try(coalesce(var.memory_free_percent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/memory-free-percent.tf
+++ b/memory-free-percent.tf
@@ -14,20 +14,20 @@ module "memory_free_percent" {
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}%"
 
   # monitor level vars
-  enabled            = var.memory_free_percent_enabled
-  alerting_enabled   = var.memory_free_percent_alerting_enabled
-  warning_threshold  = var.memory_free_percent_warning
-  critical_threshold = var.memory_free_percent_critical
-  priority           = min(var.memory_free_percent_priority + var.priority_offset, 5)
-  docs               = var.memory_free_percent_docs
-  note               = var.memory_free_percent_note
+  enabled              = var.memory_free_percent_enabled
+  alerting_enabled     = var.memory_free_percent_alerting_enabled
+  warning_threshold    = var.memory_free_percent_warning
+  critical_threshold   = var.memory_free_percent_critical
+  priority             = min(var.memory_free_percent_priority + var.priority_offset, 5)
+  docs                 = var.memory_free_percent_docs
+  note                 = var.memory_free_percent_note
+  notification_channel = try(coalesce(var.memory_free_percent_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/memory-usable-percent-variables.tf
+++ b/memory-usable-percent-variables.tf
@@ -1,0 +1,78 @@
+variable "memory_usable_percent_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "memory_usable_percent_warning" {
+  type    = number
+  default = 20
+  # 20 %
+}
+
+variable "memory_usable_percent_critical" {
+  type    = number
+  default = 10
+  # 10 %
+}
+
+variable "memory_usable_percent_evaluation_period" {
+  type    = string
+  default = "last_5m"
+}
+
+variable "memory_usable_percent_note" {
+  type    = string
+  default = ""
+}
+
+variable "memory_usable_percent_docs" {
+  type    = string
+  default = "This looks at system.mem.usable, only use this when memory_free_percent doesn't have data"
+}
+
+variable "memory_usable_percent_filter_override" {
+  type    = string
+  default = ""
+}
+
+variable "memory_usable_percent_alerting_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "memory_usable_percent_no_data_timeframe" {
+  type    = number
+  default = null
+}
+
+variable "memory_usable_percent_notify_no_data" {
+  type    = bool
+  default = false
+}
+
+variable "memory_usable_percent_ok_threshold" {
+  type    = number
+  default = null
+}
+
+variable "memory_usable_percent_name_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "memory_usable_percent_name_suffix" {
+  type    = string
+  default = ""
+}
+
+variable "memory_usable_percent_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = 2
+}
+
+variable "memory_usable_percent_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/memory-usable-percent.tf
+++ b/memory-usable-percent.tf
@@ -21,7 +21,7 @@ module "memory_usable_percent" {
   alerting_enabled     = var.memory_usable_percent_alerting_enabled
   warning_threshold    = var.memory_usable_percent_warning
   critical_threshold   = var.memory_usable_percent_critical
-  priority             = var.memory_usable_percent_priority
+  priority             = min(var.memory_usable_percent_priority + var.priority_offset, 5)
   docs                 = var.memory_usable_percent_docs
   note                 = var.memory_usable_percent_note
   notification_channel = try(coalesce(var.memory_usable_percent_notification_channel_override, var.notification_channel), "")

--- a/memory-usable-percent.tf
+++ b/memory-usable-percent.tf
@@ -1,0 +1,37 @@
+locals {
+  memory_usable_percent_filter = coalesce(
+    var.memory_usable_percent_filter_override,
+    var.filter_str
+  )
+}
+
+module "memory_usable_percent" {
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+
+  name  = "Memory Usable Percent"
+  query = "avg(${var.memory_usable_percent_evaluation_period}):100 * min:system.mem.usable{${local.memory_usable_percent_filter}} by {host} / min:system.mem.total{${local.memory_usable_percent_filter}} by {host} < ${var.memory_usable_percent_critical}"
+
+  # alert specific configuration
+  require_full_window = true
+  alert_message       = "Usable memory on CloudAMQP Node {{host.name}} has dropped below {{threshold}} and has {{value}}% available"
+  recovery_message    = "Usable memory on CloudAMQP Node {{host.name}} has recovered {{value}}%"
+
+  # monitor level vars
+  enabled              = var.memory_usable_percent_enabled
+  alerting_enabled     = var.memory_usable_percent_alerting_enabled
+  warning_threshold    = var.memory_usable_percent_warning
+  critical_threshold   = var.memory_usable_percent_critical
+  priority             = var.memory_usable_percent_priority
+  docs                 = var.memory_usable_percent_docs
+  note                 = var.memory_usable_percent_note
+  notification_channel = try(coalesce(var.memory_usable_percent_notification_channel_override, var.notification_channel), "")
+
+  # module level vars
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
+}

--- a/packets-in-errors-variables.tf
+++ b/packets-in-errors-variables.tf
@@ -46,3 +46,8 @@ variable "packets_in_errors_priority" {
   type    = number
   default = 3
 }
+
+variable "packets_in_errors_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/packets-in-errors.tf
+++ b/packets-in-errors.tf
@@ -28,10 +28,11 @@ module "packets_in_errors" {
   notification_channel = try(coalesce(var.packets_in_errors_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/packets-in-errors.tf
+++ b/packets-in-errors.tf
@@ -18,20 +18,20 @@ module "packets_in_errors" {
   recovery_message = "Packet-in error rate on ${var.service} Node {{host.name}} Recovered ({{value}} %)"
 
   # monitor level vars
-  enabled            = var.packets_in_errors_enabled
-  alerting_enabled   = var.packets_in_errors_alerting_enabled
-  warning_threshold  = var.packets_in_errors_warning
-  critical_threshold = var.packets_in_errors_critical
-  priority           = min(var.packets_in_errors_priority + var.priority_offset, 5)
-  docs               = var.packets_in_errors_docs
-  note               = var.packets_in_errors_note
+  enabled              = var.packets_in_errors_enabled
+  alerting_enabled     = var.packets_in_errors_alerting_enabled
+  warning_threshold    = var.packets_in_errors_warning
+  critical_threshold   = var.packets_in_errors_critical
+  priority             = min(var.packets_in_errors_priority + var.priority_offset, 5)
+  docs                 = var.packets_in_errors_docs
+  note                 = var.packets_in_errors_note
+  notification_channel = try(coalesce(var.packets_in_errors_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/packets-out-errors-variables.tf
+++ b/packets-out-errors-variables.tf
@@ -46,3 +46,8 @@ variable "packets_out_errors_priority" {
   type    = number
   default = 3
 }
+
+variable "packets_out_errors_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/packets-out-errors.tf
+++ b/packets-out-errors.tf
@@ -26,6 +26,7 @@ module "packets_out_errors" {
   # module level vars
   env                  = var.env
   service              = var.service
+  service_display_name = var.service_display_name
   notification_channel = try(coalesce(var.packets_out_errors_notification_channel_override, var.notification_channel), "")
   additional_tags      = var.additional_tags
   locked               = var.locked

--- a/packets-out-errors.tf
+++ b/packets-out-errors.tf
@@ -26,7 +26,7 @@ module "packets_out_errors" {
   # module level vars
   env                  = var.env
   service              = var.service
-  notification_channel = var.notification_channel
+  notification_channel = try(coalesce(var.packets_out_errors_notification_channel_override, var.notification_channel), "")
   additional_tags      = var.additional_tags
   locked               = var.locked
   name_prefix          = var.name_prefix

--- a/reboot-variables.tf
+++ b/reboot-variables.tf
@@ -29,3 +29,8 @@ variable "reboot_priority" {
   type    = number
   default = 3
 }
+
+variable "reboot_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/reboot.tf
+++ b/reboot.tf
@@ -18,17 +18,17 @@ module "reboot" {
   enabled          = var.reboot_enabled
   alerting_enabled = var.reboot_alerting_enabled
   # no warning
-  critical_threshold = 0
-  priority           = min(var.reboot_priority + var.priority_offset, 5)
-  docs               = var.reboot_docs
-  note               = var.reboot_note
+  critical_threshold   = 0
+  priority             = min(var.reboot_priority + var.priority_offset, 5)
+  docs                 = var.reboot_docs
+  note                 = var.reboot_note
+  notification_channel = try(coalesce(var.reboot_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/reboot.tf
+++ b/reboot.tf
@@ -25,10 +25,11 @@ module "reboot" {
   notification_channel = try(coalesce(var.reboot_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/required-services-variables.tf
+++ b/required-services-variables.tf
@@ -39,3 +39,8 @@ variable "required_services_default_priority" {
   type    = number
   default = 2
 }
+
+variable "required_services_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/required-services.tf
+++ b/required-services.tf
@@ -27,10 +27,11 @@ module "required_services" {
   notification_channel = try(coalesce(var.required_services_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }

--- a/required-services.tf
+++ b/required-services.tf
@@ -20,17 +20,17 @@ module "required_services" {
   enabled          = var.required_services_enabled
   alerting_enabled = var.required_services_alerting_enabled
   # no warning
-  critical_threshold = lookup(each.value, "process_count", 1)
-  priority           = min(var.required_services_default_priority + var.priority_offset, 5)
-  note               = var.required_services_default_note
-  docs               = var.required_services_default_docs
+  critical_threshold   = lookup(each.value, "process_count", 1)
+  priority             = min(var.required_services_default_priority + var.priority_offset, 5)
+  note                 = lookup(each.value, "note", var.required_services_default_note)
+  docs                 = lookup(each.value, "docs", var.required_services_default_docs)
+  notification_channel = try(coalesce(var.required_services_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/swap-variables.tf
+++ b/swap-variables.tf
@@ -46,3 +46,8 @@ variable "swap_percent_free_priority" {
   type    = number
   default = 3
 }
+
+variable "swap_percent_free_notification_channel_override" {
+  type    = string
+  default = ""
+}

--- a/swap.tf
+++ b/swap.tf
@@ -15,20 +15,20 @@ module "swap_percent_free" {
   require_full_window = false
 
   # monitor level vars
-  enabled            = var.swap_percent_free_enabled
-  alerting_enabled   = var.swap_percent_free_alerting_enabled
-  warning_threshold  = var.swap_percent_free_warning
-  critical_threshold = var.swap_percent_free_critical
-  priority           = min(var.swap_percent_free_priority + var.priority_offset, 5)
-  docs               = var.swap_percent_free_docs
-  note               = var.swap_percent_free_note
+  enabled              = var.swap_percent_free_enabled
+  alerting_enabled     = var.swap_percent_free_alerting_enabled
+  warning_threshold    = var.swap_percent_free_warning
+  critical_threshold   = var.swap_percent_free_critical
+  priority             = min(var.swap_percent_free_priority + var.priority_offset, 5)
+  docs                 = var.swap_percent_free_docs
+  note                 = var.swap_percent_free_note
+  notification_channel = try(coalesce(var.swap_percent_free_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env                  = var.env
-  service              = var.service
-  notification_channel = var.notification_channel
-  additional_tags      = var.additional_tags
-  locked               = var.locked
-  name_prefix          = var.name_prefix
-  name_suffix          = var.name_suffix
+  env             = var.env
+  service         = var.service
+  additional_tags = var.additional_tags
+  locked          = var.locked
+  name_prefix     = var.name_prefix
+  name_suffix     = var.name_suffix
 }

--- a/swap.tf
+++ b/swap.tf
@@ -25,10 +25,11 @@ module "swap_percent_free" {
   notification_channel = try(coalesce(var.swap_percent_free_notification_channel_override, var.notification_channel), "")
 
   # module level vars
-  env             = var.env
-  service         = var.service
-  additional_tags = var.additional_tags
-  locked          = var.locked
-  name_prefix     = var.name_prefix
-  name_suffix     = var.name_suffix
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
 }


### PR DESCRIPTION
This depends on another first PR: https://github.com/kabisa/terraform-datadog-system/pull/18

We seem to have a host that doesn't have memory percent free data. I'm going for the best available option `system.mem.usable` This monitor will not be created by default:

```terraform
variable "memory_usable_percent_enabled" {
  type    = bool
  default = false
}
```